### PR TITLE
Don't set max value for bar charts

### DIFF
--- a/src/components/bar_chart.rs
+++ b/src/components/bar_chart.rs
@@ -282,10 +282,8 @@ impl MockComponent for BarChart {
             let data = self.get_data(self.states.cursor, data_max_len as usize);
             let data_ref: Vec<(&str, u64)> = data.iter().map(|x| (x.0.as_str(), x.1)).collect();
             // Create widget
-            let mut widget: TuiBarChart = TuiBarChart::default()
-                .block(div)
-                .data(data_ref.as_slice())
-                .max(data_max_len);
+            let mut widget: TuiBarChart =
+                TuiBarChart::default().block(div).data(data_ref.as_slice());
             if let Some(gap) = self
                 .props
                 .get(Attribute::Custom(BAR_CHART_BARS_GAP))

--- a/src/components/sparkline.rs
+++ b/src/components/sparkline.rs
@@ -103,8 +103,8 @@ impl Sparkline {
             Some(PropPayload::Vec(list)) => {
                 let mut data: Vec<u64> = Vec::with_capacity(max);
                 list.iter()
-                    .cloned()
                     .take(max)
+                    .cloned()
                     .map(|x| x.unwrap_u64())
                     .for_each(|x| data.push(x));
                 data


### PR DESCRIPTION
## Description
As shown in the example gif [here](https://github.com/veeso/tui-realm-stdlib/blob/main/docs/images/components/bar_chart.gif), the bars on bar charts were all cropped to the number used as the maximum number of bars so they all appear the same.

As the maximum value of bars is handled by the tui library, the bar chart in this crate doesn't need to set the maximum at all,

This change probably needs the example gif updating to match but I'm not sure how they were generated. Happy to do that if you let me know how they were made.
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no new *C-bindings*
- [x] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit
