### PR TITLE
fix: select border type is not applied

### DIFF
--- a/src/components/select.rs
+++ b/src/components/select.rs
@@ -251,6 +251,7 @@ impl Select {
         let block: Block = Block::default()
             .borders(BorderSides::LEFT | BorderSides::TOP | BorderSides::RIGHT)
             .border_style(borders.style())
+            .border_type(borders.modifiers)
             .style(Style::default().bg(background));
         let title = self.props.get(Attribute::Title).map(|x| x.unwrap_title());
         let block = match title {
@@ -282,6 +283,7 @@ impl Select {
                         true => borders.style(),
                         false => Style::default(),
                     })
+                    .border_type(borders.modifiers)
                     .style(Style::default().bg(background)),
             )
             .start_corner(Corner::TopLeft)
@@ -339,6 +341,7 @@ impl Select {
         let block: Block = Block::default()
             .borders(BorderSides::ALL)
             .border_style(borders_style)
+            .border_type(borders.modifiers)
             .style(style);
         let title = self.props.get(Attribute::Title).map(|x| x.unwrap_title());
         let block = match title {


### PR DESCRIPTION
I found the select border type is not applied. I wanted to create an issue but figure it out.

## Type of change

Please select relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no new *C-bindings*
- [x] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit
