### PR TITLE
Enable chart to draw line in real time

### DIFF
--- a/src/components/chart.rs
+++ b/src/components/chart.rs
@@ -556,6 +556,19 @@ mod test {
         assert_eq!(component.max_dataset_len(), 12);
         assert_eq!(component.is_disabled(), false);
         assert_eq!(component.get_data(2, 4).len(), 2);
+        
+        let mut comp = Chart::default().data(&[
+                Dataset::default()
+                    .name("Maximum")
+                    .graph_type(GraphType::Line)
+                    .marker(Marker::Dot)
+                    .style(Style::default().fg(Color::LightRed))
+                    .data(vec![
+                        (0.0, 7.0),
+                    ]),
+        ]);
+        assert!(comp.get_data(0, 1).len() > 0);
+
         // Update and test empty data
         component.states.cursor_at_end(12);
         component.attr(

--- a/src/components/chart.rs
+++ b/src/components/chart.rs
@@ -260,12 +260,12 @@ impl<'a> Chart {
     fn get_tui_dataset(dataset: &'a Dataset, start: usize, len: usize) -> TuiDataset<'a> {
         // Recalc len
         let points = dataset.get_data();
-        let len: usize = match points.len() > start {
+        let end: usize = match points.len() > start {
             true => std::cmp::min(len, points.len() - start),
             false => 0,
         };
+
         // Prepare data storage
-        let end: usize = points.len() - len;
         TuiDataset::default()
             .name(dataset.name.clone())
             .marker(dataset.marker)


### PR DESCRIPTION

#14 - Enable chart to draw line in real time

Fixes #14 

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

I noticed that chart doesn't draw/render the line until the dataset reaches "sufficient" size. Which to me was odd since the chart widget in tuirs could be made to draw the line in "real time". 

To me everything pointed to this:
```rust
/// Only elements from `start` to `len` are preserved from dataset
    fn get_tui_dataset(dataset: &'a Dataset, start: usize, len: usize) -> TuiDataset<'a> {
        // Recalc len
        let points = dataset.get_data();
        let len: usize = match points.len() > start {
            true => std::cmp::min(len, points.len() - start),
            false => 0,
        };
        // Prepare data storage
        let end: usize = points.len() - len;
        TuiDataset::default()
            .name(dataset.name.clone())
            .marker(dataset.marker)
            .graph_type(dataset.graph_type)
            .style(dataset.style)
            .data(&points[start..end])
    }
```

If this was to be used in a "real time" scenario start (since it only ever called with `ChartState`cursor) would be 0. `points.len()` would be 1 which in turn would be less than `len` (since it's only ever called with `area.width`). This would lead to the new `len` being equal to 1. Then `end` would be == 1 - 1 => 0. Which would mean that we are trying to draw the line using a slice looking like: `[0..0]´.

I kept the rest of the match statement since if `points.len()` is less than `start` the points are out of bounds and should therefore not be drawn.

- I Removed the line on line 268 in `src/components/chart.rs"
- I also renamed `len` to `end` at line 263 in `src/components/chart.rs"

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no new *C-bindings*
- [x] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit
