### PR TITLE
fix input cursor misposition

### DIFF
--- a/src/components/input.rs
+++ b/src/components/input.rs
@@ -302,17 +302,17 @@ impl MockComponent for Input {
                 false => paragraph_style,
             };
             // Create widget
+            let block_inner_area = block.inner(area);
             let p: Paragraph = Paragraph::new(text_to_display)
                 .style(paragraph_style)
                 .block(block);
             render.render_widget(p, area);
             // Set cursor, if focus
             if focus {
-                let x: u16 = area.x
+                let x: u16 = block_inner_area.x
                     + calc_utf8_cursor_position(
                         &self.states.render_value_chars(itype)[0..self.states.cursor],
-                    )
-                    + 1;
+                    );
                 render.set_cursor(x, area.y + 1);
             }
         }


### PR DESCRIPTION
# fix: bad cursor position in inputs

## Description

Borders settings for `Input` vary where the actual text input start in the terminal, removing default borders led to wrong cursor position -- it was 1 char ahead of the text.

This PR removes a `+ 1` hack in favor of actual block inner area usage.

## Type of change

Please select relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no new *C-bindings*
- [x] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [ ] I increased or maintained the code coverage for the project, compared to the previous commit
