### PR TITLE
Avoid some string clones if not necessary

### DIFF
--- a/src/components/bar_chart.rs
+++ b/src/components/bar_chart.rs
@@ -102,11 +102,8 @@ impl BarChart {
         self
     }
 
-    pub fn title<S: AsRef<str>>(mut self, t: S, a: Alignment) -> Self {
-        self.attr(
-            Attribute::Title,
-            AttrValue::Title((t.as_ref().to_string(), a)),
-        );
+    pub fn title<S: Into<String>>(mut self, t: S, a: Alignment) -> Self {
+        self.attr(Attribute::Title, AttrValue::Title((t.into(), a)));
         self
     }
 

--- a/src/components/canvas.rs
+++ b/src/components/canvas.rs
@@ -50,11 +50,8 @@ impl Canvas {
         self
     }
 
-    pub fn title<S: AsRef<str>>(mut self, t: S, a: Alignment) -> Self {
-        self.attr(
-            Attribute::Title,
-            AttrValue::Title((t.as_ref().to_string(), a)),
-        );
+    pub fn title<S: Into<String>>(mut self, t: S, a: Alignment) -> Self {
+        self.attr(Attribute::Title, AttrValue::Title((t.into(), a)));
         self
     }
 

--- a/src/components/chart.rs
+++ b/src/components/chart.rs
@@ -103,11 +103,9 @@ impl Chart {
         self
     }
 
-    pub fn title<S: AsRef<str>>(mut self, t: S, a: Alignment) -> Self {
-        self.props.set(
-            Attribute::Title,
-            AttrValue::Title((t.as_ref().to_string(), a)),
-        );
+    pub fn title<S: Into<String>>(mut self, t: S, a: Alignment) -> Self {
+        self.props
+            .set(Attribute::Title, AttrValue::Title((t.into(), a)));
         self
     }
 
@@ -189,18 +187,18 @@ impl Chart {
         self
     }
 
-    pub fn x_title<S: AsRef<str>>(mut self, t: S) -> Self {
+    pub fn x_title<S: Into<String>>(mut self, t: S) -> Self {
         self.props.set(
             Attribute::Custom(CHART_X_TITLE),
-            AttrValue::String(t.as_ref().to_string()),
+            AttrValue::String(t.into()),
         );
         self
     }
 
-    pub fn y_title<S: AsRef<str>>(mut self, t: S) -> Self {
+    pub fn y_title<S: Into<String>>(mut self, t: S) -> Self {
         self.props.set(
             Attribute::Custom(CHART_Y_TITLE),
-            AttrValue::String(t.as_ref().to_string()),
+            AttrValue::String(t.into()),
         );
         self
     }

--- a/src/components/checkbox.rs
+++ b/src/components/checkbox.rs
@@ -143,11 +143,8 @@ impl Checkbox {
         self
     }
 
-    pub fn title<S: AsRef<str>>(mut self, t: S, a: Alignment) -> Self {
-        self.attr(
-            Attribute::Title,
-            AttrValue::Title((t.as_ref().to_string(), a)),
-        );
+    pub fn title<S: Into<String>>(mut self, t: S, a: Alignment) -> Self {
+        self.attr(Attribute::Title, AttrValue::Title((t.into(), a)));
         self
     }
 

--- a/src/components/container.rs
+++ b/src/components/container.rs
@@ -39,11 +39,8 @@ impl Container {
         self
     }
 
-    pub fn title<S: AsRef<str>>(mut self, t: S, a: Alignment) -> Self {
-        self.attr(
-            Attribute::Title,
-            AttrValue::Title((t.as_ref().to_string(), a)),
-        );
+    pub fn title<S: Into<String>>(mut self, t: S, a: Alignment) -> Self {
+        self.attr(Attribute::Title, AttrValue::Title((t.into(), a)));
         self
     }
 

--- a/src/components/input.rs
+++ b/src/components/input.rs
@@ -161,8 +161,8 @@ impl Input {
         self
     }
 
-    pub fn value<S: AsRef<str>>(mut self, s: S) -> Self {
-        self.attr(Attribute::Value, AttrValue::String(s.as_ref().to_string()));
+    pub fn value<S: Into<String>>(mut self, s: S) -> Self {
+        self.attr(Attribute::Value, AttrValue::String(s.into()));
         self
     }
 

--- a/src/components/input.rs
+++ b/src/components/input.rs
@@ -146,11 +146,8 @@ impl Input {
         self
     }
 
-    pub fn title<S: AsRef<str>>(mut self, t: S, a: Alignment) -> Self {
-        self.attr(
-            Attribute::Title,
-            AttrValue::Title((t.as_ref().to_string(), a)),
-        );
+    pub fn title<S: Into<String>>(mut self, t: S, a: Alignment) -> Self {
+        self.attr(Attribute::Title, AttrValue::Title((t.into(), a)));
         self
     }
 

--- a/src/components/input.rs
+++ b/src/components/input.rs
@@ -171,10 +171,10 @@ impl Input {
         self
     }
 
-    pub fn placeholder<S: AsRef<str>>(mut self, placeholder: S, style: Style) -> Self {
+    pub fn placeholder<S: Into<String>>(mut self, placeholder: S, style: Style) -> Self {
         self.attr(
             Attribute::Custom(INPUT_PLACEHOLDER),
-            AttrValue::String(placeholder.as_ref().to_string()),
+            AttrValue::String(placeholder.into()),
         );
         self.attr(
             Attribute::Custom(INPUT_PLACEHOLDER_STYLE),

--- a/src/components/label.rs
+++ b/src/components/label.rs
@@ -33,8 +33,8 @@ impl Label {
         self
     }
 
-    pub fn text<S: AsRef<str>>(mut self, t: S) -> Self {
-        self.attr(Attribute::Text, AttrValue::String(t.as_ref().to_string()));
+    pub fn text<S: Into<String>>(mut self, t: S) -> Self {
+        self.attr(Attribute::Text, AttrValue::String(t.into()));
         self
     }
 

--- a/src/components/label.rs
+++ b/src/components/label.rs
@@ -121,4 +121,13 @@ mod tests {
 
         assert_eq!(component.state(), State::None);
     }
+
+    #[test]
+    fn test_various_text_inputs() {
+        let _ = Label::default().text("str");
+        let _ = Label::default().text(*&"*&str");
+        let _ = Label::default().text(String::from("String"));
+        let _ = Label::default().text(&String::from("&String"));
+        let _ = Label::default().text(format!("Format"));
+    }
 }

--- a/src/components/line_gauge.rs
+++ b/src/components/line_gauge.rs
@@ -50,11 +50,8 @@ impl LineGauge {
         self
     }
 
-    pub fn title<S: AsRef<str>>(mut self, t: S, a: Alignment) -> Self {
-        self.attr(
-            Attribute::Title,
-            AttrValue::Title((t.as_ref().to_string(), a)),
-        );
+    pub fn title<S: Into<String>>(mut self, t: S, a: Alignment) -> Self {
+        self.attr(Attribute::Title, AttrValue::Title((t.into(), a)));
         self
     }
 

--- a/src/components/line_gauge.rs
+++ b/src/components/line_gauge.rs
@@ -55,8 +55,8 @@ impl LineGauge {
         self
     }
 
-    pub fn label<S: AsRef<str>>(mut self, s: S) -> Self {
-        self.attr(Attribute::Text, AttrValue::String(s.as_ref().to_string()));
+    pub fn label<S: Into<String>>(mut self, s: S) -> Self {
+        self.attr(Attribute::Text, AttrValue::String(s.into()));
         self
     }
 

--- a/src/components/list.rs
+++ b/src/components/list.rs
@@ -172,11 +172,8 @@ impl List {
         self
     }
 
-    pub fn highlighted_str<S: AsRef<str>>(mut self, s: S) -> Self {
-        self.attr(
-            Attribute::HighlightedStr,
-            AttrValue::String(s.as_ref().to_string()),
-        );
+    pub fn highlighted_str<S: Into<String>>(mut self, s: S) -> Self {
+        self.attr(Attribute::HighlightedStr, AttrValue::String(s.into()));
         self
     }
 

--- a/src/components/list.rs
+++ b/src/components/list.rs
@@ -147,11 +147,8 @@ impl List {
         self
     }
 
-    pub fn title<S: AsRef<str>>(mut self, t: S, a: Alignment) -> Self {
-        self.attr(
-            Attribute::Title,
-            AttrValue::Title((t.as_ref().to_string(), a)),
-        );
+    pub fn title<S: Into<String>>(mut self, t: S, a: Alignment) -> Self {
+        self.attr(Attribute::Title, AttrValue::Title((t.into(), a)));
         self
     }
 

--- a/src/components/paragraph.rs
+++ b/src/components/paragraph.rs
@@ -58,11 +58,8 @@ impl Paragraph {
         self
     }
 
-    pub fn title<S: AsRef<str>>(mut self, t: S, a: Alignment) -> Self {
-        self.attr(
-            Attribute::Title,
-            AttrValue::Title((t.as_ref().to_string(), a)),
-        );
+    pub fn title<S: Into<String>>(mut self, t: S, a: Alignment) -> Self {
+        self.attr(Attribute::Title, AttrValue::Title((t.into(), a)));
         self
     }
 

--- a/src/components/progress_bar.rs
+++ b/src/components/progress_bar.rs
@@ -46,8 +46,8 @@ impl ProgressBar {
         self
     }
 
-    pub fn label<S: AsRef<str>>(mut self, s: S) -> Self {
-        self.attr(Attribute::Text, AttrValue::String(s.as_ref().to_string()));
+    pub fn label<S: Into<String>>(mut self, s: S) -> Self {
+        self.attr(Attribute::Text, AttrValue::String(s.into()));
         self
     }
 

--- a/src/components/progress_bar.rs
+++ b/src/components/progress_bar.rs
@@ -41,11 +41,8 @@ impl ProgressBar {
         self
     }
 
-    pub fn title<S: AsRef<str>>(mut self, t: S, a: Alignment) -> Self {
-        self.attr(
-            Attribute::Title,
-            AttrValue::Title((t.as_ref().to_string(), a)),
-        );
+    pub fn title<S: Into<String>>(mut self, t: S, a: Alignment) -> Self {
+        self.attr(Attribute::Title, AttrValue::Title((t.into(), a)));
         self
     }
 

--- a/src/components/radio.rs
+++ b/src/components/radio.rs
@@ -121,11 +121,8 @@ impl Radio {
         self
     }
 
-    pub fn title<S: AsRef<str>>(mut self, t: S, a: Alignment) -> Self {
-        self.attr(
-            Attribute::Title,
-            AttrValue::Title((t.as_ref().to_string(), a)),
-        );
+    pub fn title<S: Into<String>>(mut self, t: S, a: Alignment) -> Self {
+        self.attr(Attribute::Title, AttrValue::Title((t.into(), a)));
         self
     }
 

--- a/src/components/select.rs
+++ b/src/components/select.rs
@@ -142,11 +142,8 @@ impl Select {
         self
     }
 
-    pub fn highlighted_str<S: AsRef<str>>(mut self, s: S) -> Self {
-        self.attr(
-            Attribute::HighlightedStr,
-            AttrValue::String(s.as_ref().to_string()),
-        );
+    pub fn highlighted_str<S: Into<String>>(mut self, s: S) -> Self {
+        self.attr(Attribute::HighlightedStr, AttrValue::String(s.into()));
         self
     }
 

--- a/src/components/select.rs
+++ b/src/components/select.rs
@@ -137,11 +137,8 @@ impl Select {
         self
     }
 
-    pub fn title<S: AsRef<str>>(mut self, t: S, a: Alignment) -> Self {
-        self.attr(
-            Attribute::Title,
-            AttrValue::Title((t.as_ref().to_string(), a)),
-        );
+    pub fn title<S: Into<String>>(mut self, t: S, a: Alignment) -> Self {
+        self.attr(Attribute::Title, AttrValue::Title((t.into(), a)));
         self
     }
 

--- a/src/components/sparkline.rs
+++ b/src/components/sparkline.rs
@@ -35,11 +35,8 @@ impl Sparkline {
         self
     }
 
-    pub fn title<S: AsRef<str>>(mut self, t: S, a: Alignment) -> Self {
-        self.attr(
-            Attribute::Title,
-            AttrValue::Title((t.as_ref().to_string(), a)),
-        );
+    pub fn title<S: Into<String>>(mut self, t: S, a: Alignment) -> Self {
+        self.attr(Attribute::Title, AttrValue::Title((t.into(), a)));
         self
     }
 

--- a/src/components/spinner.rs
+++ b/src/components/spinner.rs
@@ -69,8 +69,8 @@ impl Spinner {
         self
     }
 
-    pub fn sequence<S: AsRef<str>>(mut self, s: S) -> Self {
-        self.attr(Attribute::Text, AttrValue::String(s.as_ref().to_string()));
+    pub fn sequence<S: Into<String>>(mut self, s: S) -> Self {
+        self.attr(Attribute::Text, AttrValue::String(s.into()));
         self
     }
 }

--- a/src/components/table.rs
+++ b/src/components/table.rs
@@ -167,11 +167,8 @@ impl Table {
         self
     }
 
-    pub fn highlighted_str<S: AsRef<str>>(mut self, s: S) -> Self {
-        self.attr(
-            Attribute::HighlightedStr,
-            AttrValue::String(s.as_ref().to_string()),
-        );
+    pub fn highlighted_str<S: Into<String>>(mut self, s: S) -> Self {
+        self.attr(Attribute::HighlightedStr, AttrValue::String(s.into()));
         self
     }
 

--- a/src/components/table.rs
+++ b/src/components/table.rs
@@ -152,11 +152,8 @@ impl Table {
         self
     }
 
-    pub fn title<S: AsRef<str>>(mut self, t: S, a: Alignment) -> Self {
-        self.attr(
-            Attribute::Title,
-            AttrValue::Title((t.as_ref().to_string(), a)),
-        );
+    pub fn title<S: Into<String>>(mut self, t: S, a: Alignment) -> Self {
+        self.attr(Attribute::Title, AttrValue::Title((t.into(), a)));
         self
     }
 

--- a/src/components/textarea.rs
+++ b/src/components/textarea.rs
@@ -149,11 +149,8 @@ impl Textarea {
         self
     }
 
-    pub fn title<S: AsRef<str>>(mut self, t: S, a: Alignment) -> Self {
-        self.attr(
-            Attribute::Title,
-            AttrValue::Title((t.as_ref().to_string(), a)),
-        );
+    pub fn title<S: Into<String>>(mut self, t: S, a: Alignment) -> Self {
+        self.attr(Attribute::Title, AttrValue::Title((t.into(), a)));
         self
     }
 

--- a/src/components/textarea.rs
+++ b/src/components/textarea.rs
@@ -159,11 +159,8 @@ impl Textarea {
         self
     }
 
-    pub fn highlighted_str<S: AsRef<str>>(mut self, s: S) -> Self {
-        self.attr(
-            Attribute::HighlightedStr,
-            AttrValue::String(s.as_ref().to_string()),
-        );
+    pub fn highlighted_str<S: Into<String>>(mut self, s: S) -> Self {
+        self.attr(Attribute::HighlightedStr, AttrValue::String(s.into()));
         self
     }
 


### PR DESCRIPTION
# Avoid some string clones if not necessary

(No issue created for this)

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

List here your changes

- Change code to not *always* clone (and so allocate) a string, if the input is already a string

## Type of change

Please select relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which enhances existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no new *C-bindings*
- [x] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [ ] I increased or maintained the code coverage for the project, compared to the previous commit

---

This change should be non-breaking for the most common use-cases, as seen in the test that was not modified, but there may be custom types outside which do not implement `Into<String>`, but `AsRef<str>` (which i think is quite niche and can be fixed on the user side)

Main use-case i see is for passing in `format!()` values, which are already Strings and so should not need to be cloned.