### PR TITLE
fix canvas Y bounds incorrectly using X bounds

### DIFF
--- a/src/components/canvas.rs
+++ b/src/components/canvas.rs
@@ -180,7 +180,7 @@ impl MockComponent for Canvas {
                 .unwrap_or([0.0, 0.0]);
             let y_bounds: [f64; 2] = self
                 .props
-                .get(Attribute::Custom(CANVAS_X_BOUNDS))
+                .get(Attribute::Custom(CANVAS_Y_BOUNDS))
                 .map(|x| x.unwrap_payload().unwrap_tup2())
                 .map(|(a, b)| [a.unwrap_f64(), b.unwrap_f64()])
                 .unwrap_or([0.0, 0.0]);


### PR DESCRIPTION
# 23 - Fix canvas Y bounds incorrectly using X bounds

Fixes #23

## Description

Fix obvious typo

## Type of change

Please select relevant options.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [X] My code follows the contribution guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I formatted the code with `cargo fmt`
- [X] I checked my code using `cargo clippy` and reports no warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have introduced no new *C-bindings*
- [ ] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [ ] I increased or maintained the code coverage for the project, compared to the previous commit
