### PR TITLE
Remove chart truncation to area width

### DIFF
--- a/src/components/chart.rs
+++ b/src/components/chart.rs
@@ -230,8 +230,8 @@ impl Chart {
 
     /// ### data
     ///
-    /// Get data to be displayed, starting from provided index at `start` with a max length of `len`
-    fn get_data(&mut self, start: usize, len: usize) -> Vec<TuiDataset> {
+    /// Get data to be displayed, starting from provided index at `start`
+    fn get_data(&mut self, start: usize) -> Vec<TuiDataset> {
         self.states.data = self
             .props
             .get(Attribute::Dataset)
@@ -246,7 +246,7 @@ impl Chart {
         self.states
             .data
             .iter()
-            .map(|x| Self::get_tui_dataset(x, start, len))
+            .map(|x| Self::get_tui_dataset(x, start))
             .collect()
     }
 }
@@ -255,14 +255,9 @@ impl<'a> Chart {
     /// ### get_tui_dataset
     ///
     /// Create tui_dataset from dataset
-    /// Only elements from `start` to `len` are preserved from dataset
-    fn get_tui_dataset(dataset: &'a Dataset, start: usize, len: usize) -> TuiDataset<'a> {
-        // Recalc len
+    /// Only elements from `start` to the end
+    fn get_tui_dataset(dataset: &'a Dataset, start: usize) -> TuiDataset<'a> {
         let points = dataset.get_data();
-        let end: usize = match points.len() > start {
-            true => std::cmp::min(len, points.len() - start),
-            false => 0,
-        };
 
         // Prepare data storage
         TuiDataset::default()
@@ -270,7 +265,7 @@ impl<'a> Chart {
             .marker(dataset.marker)
             .graph_type(dataset.graph_type)
             .style(dataset.style)
-            .data(&points[start..end])
+            .data(&points[start..])
     }
 }
 
@@ -373,7 +368,7 @@ impl MockComponent for Chart {
                 ));
             }
             // Get data
-            let data: Vec<TuiDataset> = self.get_data(self.states.cursor, area.width as usize);
+            let data: Vec<TuiDataset> = self.get_data(self.states.cursor);
             // Build widget
             let widget: TuiChart = TuiChart::new(data).block(div).x_axis(x_axis).y_axis(y_axis);
             // Render
@@ -542,7 +537,7 @@ mod test {
         // component funcs
         assert_eq!(component.max_dataset_len(), 12);
         assert_eq!(component.is_disabled(), false);
-        assert_eq!(component.get_data(2, 4).len(), 2);
+        assert_eq!(component.get_data(2).len(), 2);
 
         let mut comp = Chart::default().data(&[Dataset::default()
             .name("Maximum")
@@ -550,7 +545,7 @@ mod test {
             .marker(Marker::Dot)
             .style(Style::default().fg(Color::LightRed))
             .data(vec![(0.0, 7.0)])]);
-        assert!(comp.get_data(0, 1).len() > 0);
+        assert!(!comp.get_data(0).is_empty());
 
         // Update and test empty data
         component.states.cursor_at_end(12);


### PR DESCRIPTION
# 25 - Remove chart truncation to area width

Fixes #25 

## Description

Charts were truncated to area width, which does not seem necessary as the chart backend (ratatui) will adapt to the viewport anyway.

List here your changes

- Removed the `len` parameter from `get_data` and `get_tui_dataset`
- Fixed tests

## Type of change

Please select relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have introduced no new *C-bindings*
- [ ] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [ ] I increased or maintained the code coverage for the project, compared to the previous commit
