### PR TITLE
Dont clone full TextSpans in `Span`

### DIFF
--- a/src/components/span.rs
+++ b/src/components/span.rs
@@ -8,7 +8,7 @@ use tuirealm::props::{
     Alignment, AttrValue, Attribute, Color, PropPayload, PropValue, Props, Style, TextModifiers,
     TextSpan,
 };
-use tuirealm::ratatui::text::Line as Spans;
+use tuirealm::ratatui::text::Line;
 use tuirealm::ratatui::{
     layout::Rect,
     text::{Span as TuiSpan, Text},
@@ -95,7 +95,7 @@ impl MockComponent for Span {
                     .collect(),
                 _ => Vec::new(),
             };
-            let text: Text = Text::from(Spans::from(spans));
+            let text: Text = Text::from(Line::from(spans));
             // Text properties
             let alignment: Alignment = self
                 .props


### PR DESCRIPTION
# ISSUE _NUMBER_ - PULL_REQUEST_TITLE

No issue created

## Description

This PR changes `Span`'s `view` to not always clone all `TextSpan`s and instead uses references, as ratatui uses `Cow<str>`.

## Type of change

Please select relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no new *C-bindings*
- [x] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit

---

PS: i dont think the coverage test failure is related to any changes in this PR