### PR TITLE
Change utils

### DIFF
--- a/src/components/bar_chart.rs
+++ b/src/components/bar_chart.rs
@@ -231,7 +231,10 @@ impl MockComponent for BarChart {
                 .props
                 .get_or(Attribute::Borders, AttrValue::Borders(Borders::default()))
                 .unwrap_borders();
-            let title = self.props.get(Attribute::Title).map(|x| x.unwrap_title());
+            let title = self
+                .props
+                .get_ref(Attribute::Title)
+                .and_then(|x| x.as_title());
             let focus = self
                 .props
                 .get_or(Attribute::Focus, AttrValue::Flag(false))

--- a/src/components/canvas.rs
+++ b/src/components/canvas.rs
@@ -164,7 +164,10 @@ impl MockComponent for Canvas {
                 .props
                 .get_or(Attribute::Borders, AttrValue::Borders(Borders::default()))
                 .unwrap_borders();
-            let title = self.props.get(Attribute::Title).map(|x| x.unwrap_title());
+            let title = self
+                .props
+                .get_ref(Attribute::Title)
+                .and_then(|x| x.as_title());
             let focus = self
                 .props
                 .get_or(Attribute::Focus, AttrValue::Flag(false))

--- a/src/components/chart.rs
+++ b/src/components/chart.rs
@@ -284,7 +284,12 @@ impl MockComponent for Chart {
                 .props
                 .get_or(Attribute::Borders, AttrValue::Borders(Borders::default()))
                 .unwrap_borders();
-            let title = self.props.get(Attribute::Title).map(|x| x.unwrap_title());
+            let title = self
+                .props
+                .get_ref(Attribute::Title)
+                .and_then(|x| x.as_title())
+                // this needs to be cloned as "self" is later mutably borrowed, while this immutably borrows "self"
+                .cloned();
             let focus = self
                 .props
                 .get_or(Attribute::Focus, AttrValue::Flag(false))
@@ -297,7 +302,7 @@ impl MockComponent for Chart {
                 true => true,
                 false => focus,
             };
-            let div = crate::utils::get_block(borders, title, active, inactive_style);
+            let div = crate::utils::get_block(borders, title.as_ref(), active, inactive_style);
             // Create widget
             // -- x axis
             let mut x_axis: Axis = Axis::default();

--- a/src/components/checkbox.rs
+++ b/src/components/checkbox.rs
@@ -201,7 +201,10 @@ impl MockComponent for Checkbox {
                 .props
                 .get_or(Attribute::Borders, AttrValue::Borders(Borders::default()))
                 .unwrap_borders();
-            let title = self.props.get(Attribute::Title).map(|x| x.unwrap_title());
+            let title = self
+                .props
+                .get_ref(Attribute::Title)
+                .and_then(|x| x.as_title());
             let focus = self
                 .props
                 .get_or(Attribute::Focus, AttrValue::Flag(false))

--- a/src/components/container.rs
+++ b/src/components/container.rs
@@ -64,7 +64,10 @@ impl MockComponent for Container {
                 .props
                 .get_or(Attribute::Borders, AttrValue::Borders(Borders::default()))
                 .unwrap_borders();
-            let title = self.props.get(Attribute::Title).map(|x| x.unwrap_title());
+            let title = self
+                .props
+                .get_ref(Attribute::Title)
+                .and_then(|x| x.as_title());
             let div = crate::utils::get_block(borders, title, true, None);
             // Render block
             render.render_widget(div, area);

--- a/src/components/input.rs
+++ b/src/components/input.rs
@@ -222,13 +222,7 @@ impl MockComponent for Input {
                     AttrValue::TextModifiers(TextModifiers::empty()),
                 )
                 .unwrap_text_modifiers();
-            let title = self
-                .props
-                .get_or(
-                    Attribute::Title,
-                    AttrValue::Title((String::default(), Alignment::Center)),
-                )
-                .unwrap_title();
+            let title = crate::utils::get_title_or_center(&self.props);
             let borders = self
                 .props
                 .get_or(Attribute::Borders, AttrValue::Borders(Borders::default()))
@@ -242,7 +236,7 @@ impl MockComponent for Input {
                 .get(Attribute::FocusStyle)
                 .map(|x| x.unwrap_style());
             let itype = self.get_input_type();
-            let mut block = crate::utils::get_block(borders, Some(title), focus, inactive_style);
+            let mut block = crate::utils::get_block(borders, Some(&title), focus, inactive_style);
             // Apply invalid style
             if focus && !self.is_valid() {
                 if let Some(style) = self
@@ -255,14 +249,7 @@ impl MockComponent for Input {
                         .get_or(Attribute::Borders, AttrValue::Borders(Borders::default()))
                         .unwrap_borders()
                         .color(style.fg.unwrap_or(Color::Reset));
-                    let title = self
-                        .props
-                        .get_or(
-                            Attribute::Title,
-                            AttrValue::Title((String::default(), Alignment::Center)),
-                        )
-                        .unwrap_title();
-                    block = crate::utils::get_block(borders, Some(title), focus, None);
+                    block = crate::utils::get_block(borders, Some(&title), focus, None);
                     foreground = style.fg.unwrap_or(Color::Reset);
                     background = style.bg.unwrap_or(Color::Reset);
                 }

--- a/src/components/line_gauge.rs
+++ b/src/components/line_gauge.rs
@@ -143,7 +143,10 @@ impl MockComponent for LineGauge {
                     AttrValue::TextModifiers(TextModifiers::empty()),
                 )
                 .unwrap_text_modifiers();
-            let title = self.props.get(Attribute::Title).map(|x| x.unwrap_title());
+            let title = self
+                .props
+                .get_ref(Attribute::Title)
+                .and_then(|x| x.as_title());
             // Get percentage
             let percentage = self
                 .props

--- a/src/components/list.rs
+++ b/src/components/list.rs
@@ -225,13 +225,7 @@ impl MockComponent for List {
                     AttrValue::TextModifiers(TextModifiers::empty()),
                 )
                 .unwrap_text_modifiers();
-            let title = self
-                .props
-                .get_or(
-                    Attribute::Title,
-                    AttrValue::Title((String::default(), Alignment::Center)),
-                )
-                .unwrap_title();
+            let title = crate::utils::get_title_or_center(&self.props);
             let borders = self
                 .props
                 .get_or(Attribute::Borders, AttrValue::Borders(Borders::default()))
@@ -248,7 +242,7 @@ impl MockComponent for List {
                 true => focus,
                 false => true,
             };
-            let div = crate::utils::get_block(borders, Some(title), active, inactive_style);
+            let div = crate::utils::get_block(borders, Some(&title), active, inactive_style);
             // Make list entries
             let list_items: Vec<ListItem> = match self
                 .props

--- a/src/components/paragraph.rs
+++ b/src/components/paragraph.rs
@@ -130,7 +130,10 @@ impl MockComponent for Paragraph {
                 .props
                 .get_or(Attribute::Borders, AttrValue::Borders(Borders::default()))
                 .unwrap_borders();
-            let title = self.props.get(Attribute::Title).map(|x| x.unwrap_title());
+            let title = self
+                .props
+                .get_ref(Attribute::Title)
+                .and_then(|x| x.as_title());
             let div = crate::utils::get_block(borders, title, true, None);
             render.render_widget(
                 TuiParagraph::new(text)

--- a/src/components/progress_bar.rs
+++ b/src/components/progress_bar.rs
@@ -95,7 +95,10 @@ impl MockComponent for ProgressBar {
                 .props
                 .get_or(Attribute::Borders, AttrValue::Borders(Borders::default()))
                 .unwrap_borders();
-            let title = self.props.get(Attribute::Title).map(|x| x.unwrap_title());
+            let title = self
+                .props
+                .get_ref(Attribute::Title)
+                .and_then(|x| x.as_title());
             // Get percentage
             let percentage = self
                 .props

--- a/src/components/radio.rs
+++ b/src/components/radio.rs
@@ -184,7 +184,10 @@ impl MockComponent for Radio {
                 .props
                 .get_or(Attribute::Borders, AttrValue::Borders(Borders::default()))
                 .unwrap_borders();
-            let title = self.props.get(Attribute::Title).map(|x| x.unwrap_title());
+            let title = self
+                .props
+                .get_ref(Attribute::Title)
+                .and_then(|x| x.as_title());
             let focus = self
                 .props
                 .get_or(Attribute::Focus, AttrValue::Flag(false))

--- a/src/components/sparkline.rs
+++ b/src/components/sparkline.rs
@@ -99,13 +99,7 @@ impl MockComponent for Sparkline {
                 .props
                 .get_or(Attribute::Background, AttrValue::Color(Color::Reset))
                 .unwrap_color();
-            let title = self
-                .props
-                .get_or(
-                    Attribute::Title,
-                    AttrValue::Title((String::default(), Alignment::Center)),
-                )
-                .unwrap_title();
+            let title = crate::utils::get_title_or_center(&self.props);
             let borders = self
                 .props
                 .get_or(Attribute::Borders, AttrValue::Borders(Borders::default()))
@@ -118,7 +112,7 @@ impl MockComponent for Sparkline {
             let data: Vec<u64> = self.get_data(max_entries);
             // Create widget
             let widget: TuiSparkline = TuiSparkline::default()
-                .block(crate::utils::get_block(borders, Some(title), false, None))
+                .block(crate::utils::get_block(borders, Some(&title), false, None))
                 .data(data.as_slice())
                 .max(max_entries as u64)
                 .style(Style::default().fg(foreground).bg(background));

--- a/src/components/table.rs
+++ b/src/components/table.rs
@@ -290,13 +290,7 @@ impl MockComponent for Table {
                     AttrValue::TextModifiers(TextModifiers::empty()),
                 )
                 .unwrap_text_modifiers();
-            let title = self
-                .props
-                .get_or(
-                    Attribute::Title,
-                    AttrValue::Title((String::default(), Alignment::Center)),
-                )
-                .unwrap_title();
+            let title = crate::utils::get_title_or_center(&self.props);
             let borders = self
                 .props
                 .get_or(Attribute::Borders, AttrValue::Borders(Borders::default()))
@@ -346,7 +340,7 @@ impl MockComponent for Table {
 
             let mut table = TuiTable::new(rows, &widths).block(crate::utils::get_block(
                 borders,
-                Some(title),
+                Some(&title),
                 focus,
                 inactive_style,
             ));

--- a/src/components/textarea.rs
+++ b/src/components/textarea.rs
@@ -197,7 +197,7 @@ impl MockComponent for Textarea {
                     .iter()
                     // this will skip any "PropValue" that is not a "TextSpan", instead of panicing
                     .flat_map(|x| x.as_text_span())
-                    .map(|x| crate::utils::wrap_spans(&[x.clone()], wrap_width, &self.props))
+                    .map(|x| crate::utils::wrap_spans(&[x], wrap_width, &self.props))
                     .map(ListItem::new)
                     .collect(),
                 _ => Vec::new(),

--- a/src/components/textarea.rs
+++ b/src/components/textarea.rs
@@ -217,13 +217,7 @@ impl MockComponent for Textarea {
                     AttrValue::TextModifiers(TextModifiers::empty()),
                 )
                 .unwrap_text_modifiers();
-            let title = self
-                .props
-                .get_or(
-                    Attribute::Title,
-                    AttrValue::Title((String::default(), Alignment::Center)),
-                )
-                .unwrap_title();
+            let title = crate::utils::get_title_or_center(&self.props);
             let borders = self
                 .props
                 .get_or(Attribute::Borders, AttrValue::Borders(Borders::default()))
@@ -243,7 +237,7 @@ impl MockComponent for Textarea {
             let mut list = List::new(lines)
                 .block(crate::utils::get_block(
                     borders,
-                    Some(title),
+                    Some(&title),
                     focus,
                     inactive_style,
                 ))

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -109,13 +109,15 @@ pub fn use_or_default_styles(props: &Props, span: &TextSpan) -> (Color, Color, M
 ///
 /// Construct a block for widget using block properties.
 /// If focus is true the border color is applied, otherwise inactive_style
-pub fn get_block<'a>(
+pub fn get_block<T: AsRef<str>>(
     props: Borders,
-    title: Option<(String, Alignment)>,
+    title: Option<&(T, Alignment)>,
     focus: bool,
     inactive_style: Option<Style>,
-) -> Block<'a> {
-    let title = title.unwrap_or((String::default(), Alignment::Left));
+) -> Block {
+    let title = title
+        .map(|v| (v.0.as_ref(), v.1))
+        .unwrap_or(("", Alignment::Left));
     Block::default()
         .borders(props.sides)
         .border_style(match focus {
@@ -127,6 +129,15 @@ pub fn get_block<'a>(
         .border_type(props.modifiers)
         .title(title.0)
         .title_alignment(title.1)
+}
+
+/// Get the [`Attribute::Title`] or a Centered default
+pub fn get_title_or_center(props: &Props) -> (&str, Alignment) {
+    props
+        .get_ref(Attribute::Title)
+        .and_then(|v| v.as_title())
+        .map(|v| (v.0.as_str(), v.1))
+        .unwrap_or(("", Alignment::Center))
 }
 
 /// ### calc_utf8_cursor_position
@@ -218,11 +229,11 @@ mod test {
             .modifiers(BorderType::Rounded);
         get_block(
             props.clone(),
-            Some(("title".to_string(), Alignment::Center)),
+            Some(&("title", Alignment::Center)),
             true,
             None,
         );
-        get_block(props, None, false, None);
+        get_block::<&str>(props, None, false, None);
     }
 
     #[test]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -19,7 +19,7 @@ use unicode_width::UnicodeWidthStr;
 ///
 /// Given a vector of `TextSpans`, it creates a list of `Spans` which mustn't exceed the provided width parameter.
 /// Each `Spans` in the returned `Vec` is a line in the text.
-pub fn wrap_spans<'a>(spans: &[TextSpan], width: usize, props: &Props) -> Vec<Spans<'a>> {
+pub fn wrap_spans<'a>(spans: &[&TextSpan], width: usize, props: &Props) -> Vec<Spans<'a>> {
     // Prepare result (capacity will be at least spans.len)
     let mut res: Vec<Spans> = Vec::with_capacity(spans.len());
     // Prepare environment
@@ -156,17 +156,20 @@ mod test {
         props.set(Attribute::Background, AttrValue::Color(Color::White));
         // Prepare spans; let's start with two simple spans, which fits the line
         let spans: Vec<TextSpan> = vec![TextSpan::from("hello, "), TextSpan::from("world!")];
+        let spans: Vec<&TextSpan> = spans.iter().collect();
         assert_eq!(wrap_spans(&spans, 64, &props).len(), 1);
         // Let's make a sentence, which would require two lines
         let spans: Vec<TextSpan> = vec![
             TextSpan::from("Hello, everybody, I'm Uncle Camel!"),
             TextSpan::from("How's it going today?"),
         ];
+        let spans: Vec<&TextSpan> = spans.iter().collect();
         assert_eq!(wrap_spans(&spans, 32, &props).len(), 2);
         // Let's make a sentence, which requires 3 lines, but with only one span
         let spans: Vec<TextSpan> = vec![TextSpan::from(
             "Hello everybody! My name is Uncle Camel. How's it going today?",
         )];
+        let spans: Vec<&TextSpan> = spans.iter().collect();
         // makes Hello everybody, my name is uncle, camel. how's it, goind today
         assert_eq!(wrap_spans(&spans, 16, &props).len(), 4);
         // Combine
@@ -176,6 +179,7 @@ mod test {
             TextSpan::from("In posuere sollicitudin vulputate"),
             TextSpan::from("Sed vitae rutrum quam."),
         ];
+        let spans: Vec<&TextSpan> = spans.iter().collect();
         // "Lorem ipsum dolor sit amet,", "consectetur adipiscing elit. Canem!", "In posuere sollicitudin vulputate", "Sed vitae rutrum quam."
         assert_eq!(wrap_spans(&spans, 36, &props).len(), 4);
     }


### PR DESCRIPTION
# ISSUE _NUMBER_ - PULL_REQUEST_TITLE

Requires the following to be merged and released:
- https://github.com/veeso/tui-realm/pull/88
- https://github.com/veeso/tui-realm/pull/89
- https://github.com/veeso/tui-realm/pull/91

re #30

## Description

This PR changes some `utils` code:
- add utility function `get_title_or_center` (as it is a common enough operation)
- change `wrap_spans` to accept `&[&TextSpan]` (instead of `&[TextSpan]`); this allows it to be called on referenced `TextSpan`s instead of having to clone, see the `TextArea` change
- change `get_block`'s `title` to accept `Option<&(AsRef<str>, ..)>` (instead of `Option<(String, ..)>`); this allows it to be called with returns from `props.get_ref` instead of having to clone the string inside, while also allowing to be called with `&str`, `&String` and `String`.

## Type of change

Please select relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no new *C-bindings*
- [x] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit
