### PR TITLE
Some more clone avoidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ Unreleased
 - Change `Chart::data` to take a iterator to clone less values.
 - Change `CheckboxStates::set_choices` to take a `Into<Vec<String>>` to clone less values.
 - Change `Checkbox::choices` to take a iterator to clone less values.
+- Change `RadioStates::set_choices` to take a `Into<Vec<String>>` to clone less values.
+- Change `RadioStates::choices` to take a iterator to clone less values.
 
 ## 2.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ Unreleased
 - Change `Paragraph::text` to take a iterator to clone less values.
 - Change `Canvas::data` to take a iterator to clone less values.
 - Change `Chart::data` to take a iterator to clone less values.
+- Change `CheckboxStates::set_choices` to take a `Into<Vec<String>>` to clone less values.
+- Change `Checkbox::choices` to take a iterator to clone less values.
 
 ## 2.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Unreleased
 
 - Change `Paragraph::text` to take a iterator to clone less values.
 - Change `Span::spans` to take a iterator to clone less values.
+- Change `Textarea::text_rows` to take a iterator to clone less values.
 - Change `Canvas::data` to take a iterator to clone less values.
 - Change `Chart::data` to take a iterator to clone less values.
 - Change `CheckboxStates::set_choices` to take a `Into<Vec<String>>` to clone less values.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Unreleased
 
 - Change `Paragraph::text` to take a iterator to clone less values.
 - Change `Canvas::data` to take a iterator to clone less values.
+- Change `Chart::data` to take a iterator to clone less values.
 
 ## 2.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ Unreleased
 - Change `Checkbox::choices` to take a iterator to clone less values.
 - Change `RadioStates::set_choices` to take a `Into<Vec<String>>` to clone less values.
 - Change `RadioStates::choices` to take a iterator to clone less values.
+- Change `SelectStates::set_choices` to take a `Into<Vec<String>>` to clone less values.
+- Change `Select::choices` to take a iterator to clone less values.
 
 ## 2.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 Unreleased
 
 - Change `Paragraph::text` to take a iterator to clone less values.
+- Change `Canvas::data` to take a iterator to clone less values.
 
 ## 2.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@
 
 ---
 
+## next
+
+Unreleased
+
+- Change `Paragraph::text` to take a iterator to clone less values.
+
 ## 2.0.1
 
 Released on 13/10/2024

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Unreleased
 - Change `RadioStates::choices` to take a iterator to clone less values.
 - Change `SelectStates::set_choices` to take a `Into<Vec<String>>` to clone less values.
 - Change `Select::choices` to take a iterator to clone less values.
+- Change `Table::headers` to take a iterator to clone less values.
 
 ## 2.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 Unreleased
 
 - Change `Paragraph::text` to take a iterator to clone less values.
+- Change `Span::spans` to take a iterator to clone less values.
 - Change `Canvas::data` to take a iterator to clone less values.
 - Change `Chart::data` to take a iterator to clone less values.
 - Change `CheckboxStates::set_choices` to take a `Into<Vec<String>>` to clone less values.

--- a/examples/canvas.rs
+++ b/examples/canvas.rs
@@ -123,7 +123,7 @@ impl Default for MyCanvas {
                 .marker(Marker::Dot)
                 .x_bounds((-180.0, 180.0))
                 .y_bounds((-90.0, 90.0))
-                .data(&[
+                .data([
                     Shape::Label((24.0, 34.0, String::from("Hello!"), Color::Cyan)),
                     Shape::Layer,
                     Shape::Map(Map {

--- a/examples/checkbox.rs
+++ b/examples/checkbox.rs
@@ -150,7 +150,7 @@ impl Default for CheckboxAlfa {
                 .background(Color::Black)
                 .title("Select your ice cream flavours 🍦", Alignment::Center)
                 .rewind(true)
-                .choices(&[
+                .choices([
                     "vanilla",
                     "chocolate",
                     "coconut",
@@ -206,7 +206,7 @@ impl Default for CheckboxBeta {
                 .background(Color::Black)
                 .title("Select your toppings 🧁", Alignment::Center)
                 .rewind(false)
-                .choices(&[
+                .choices([
                     "hazelnuts",
                     "chocolate",
                     "maple cyrup",

--- a/examples/container.rs
+++ b/examples/container.rs
@@ -145,7 +145,7 @@ impl Default for MyContainer {
                             .rewind(true)
                             .step(4)
                             .row_height(1)
-                            .headers(&["Key", "Msg", "Description"])
+                            .headers(["Key", "Msg", "Description"])
                             .column_spacing(3)
                             .widths(&[30, 20, 50])
                             .table(
@@ -194,7 +194,7 @@ impl Default for MyContainer {
                             .highlighted_color(Color::Green)
                             .highlighted_str(">> ")
                             .row_height(1)
-                            .headers(&["Key", "Msg", "Description"])
+                            .headers(["Key", "Msg", "Description"])
                             .column_spacing(3)
                             .widths(&[30, 20, 50])
                             .table(

--- a/examples/paragraph.rs
+++ b/examples/paragraph.rs
@@ -148,7 +148,7 @@ impl Default for ParagraphAlfa {
                 .background(Color::Black)
                 .title("Lorem ipsum (wrap)", Alignment::Center)
                 .wrap(true)
-                .text(&[
+                .text([
                     TextSpan::new("Lorem ipsum dolor sit amet,").underlined().fg(Color::Green),
                     TextSpan::from("consectetur adipiscing elit. Praesent mauris est, vehicula et imperdiet sed, tincidunt sed est. Sed sed dui odio. Etiam nunc neque, sodales ut ex nec, tincidunt malesuada eros. Sed quis eros non felis sodales accumsan in ac risus"),
                     TextSpan::from("                       Duis augue diam, tempor vitae posuere et, tempus mattis ligula.")
@@ -185,7 +185,7 @@ impl Default for ParagraphBeta {
                 .background(Color::Black)
                 .title("Lorem ipsum (no wrap)", Alignment::Center)
                 .wrap(false)
-                .text(&[
+                .text([
                     TextSpan::new("Lorem ipsum dolor sit amet,").underlined().fg(Color::Green),
                     TextSpan::from("consectetur adipiscing elit. Praesent mauris est, vehicula et imperdiet sed, tincidunt sed est. Sed sed dui odio. Etiam nunc neque, sodales ut ex nec, tincidunt malesuada eros. Sed quis eros non felis sodales accumsan in ac risus"),
                     TextSpan::from("                                        Duis augue diam, tempor vitae posuere et, tempus mattis ligula.")

--- a/examples/radio.rs
+++ b/examples/radio.rs
@@ -149,7 +149,7 @@ impl Default for RadioAlfa {
                 .foreground(Color::LightGreen)
                 .title("Select your ice cream flavour 🍦", Alignment::Center)
                 .rewind(true)
-                .choices(&[
+                .choices([
                     "vanilla",
                     "chocolate",
                     "coconut",
@@ -200,7 +200,7 @@ impl Default for RadioBeta {
                 .foreground(Color::LightYellow)
                 .title("Select your topping 🧁", Alignment::Center)
                 .rewind(false)
-                .choices(&[
+                .choices([
                     "hazelnuts",
                     "chocolate",
                     "maple cyrup",

--- a/examples/select.rs
+++ b/examples/select.rs
@@ -162,7 +162,7 @@ impl Default for SelectAlfa {
                 .rewind(true)
                 .highlighted_color(Color::LightGreen)
                 .highlighted_str(">> ")
-                .choices(&[
+                .choices([
                     "vanilla",
                     "chocolate",
                     "coconut",
@@ -219,7 +219,7 @@ impl Default for SelectBeta {
                 .rewind(false)
                 .highlighted_color(Color::LightYellow)
                 .highlighted_str(">> ")
-                .choices(&[
+                .choices([
                     "hazelnuts",
                     "chocolate",
                     "maple cyrup",

--- a/examples/span.rs
+++ b/examples/span.rs
@@ -133,7 +133,7 @@ impl Default for SpanAlfa {
         Self {
             component: Span::default()
                 .foreground(Color::Yellow)
-                .spans(&[
+                .spans([
                     TextSpan::new("Lorem ipsum dolor sit amet,").underlined().fg(Color::Green),
                     TextSpan::from("consectetur adipiscing elit. Praesent mauris est, vehicula et imperdiet sed, tincidunt sed est."),
                 ])
@@ -164,7 +164,7 @@ impl Default for SpanBeta {
                 .background(Color::White)
                 .alignment(Alignment::Right)
                 .modifiers(TextModifiers::BOLD)
-                .spans(&[
+                .spans([
                     TextSpan::new("Lorem ipsum dolor sit amet,").underlined().fg(Color::Green).bg(Color::Red),
                     TextSpan::from("consectetur adipiscing elit. Praesent mauris est, vehicula et imperdiet sed, tincidunt sed est."),
                 ])

--- a/examples/spinner.rs
+++ b/examples/spinner.rs
@@ -147,7 +147,7 @@ struct SpanAlfa {
 impl Default for SpanAlfa {
     fn default() -> Self {
         Self {
-            component: Span::default().foreground(Color::Yellow).spans(&[
+            component: Span::default().foreground(Color::Yellow).spans([
                 TextSpan::new("Downloading tui-realm... ")
                     .underlined()
                     .fg(Color::Green),
@@ -180,7 +180,7 @@ impl Default for SpanBeta {
                 .background(Color::White)
                 .alignment(Alignment::Right)
                 .modifiers(TextModifiers::BOLD)
-                .spans(&[
+                .spans([
                     TextSpan::new("Downloading tui-realm-stdlib... ")
                         .underlined()
                         .fg(Color::Green),

--- a/examples/table.rs
+++ b/examples/table.rs
@@ -153,7 +153,7 @@ impl Default for TableAlfa {
                 .rewind(true)
                 .step(4)
                 .row_height(1)
-                .headers(&["Key", "Msg", "Description"])
+                .headers(["Key", "Msg", "Description"])
                 .column_spacing(3)
                 .widths(&[30, 20, 50])
                 .table(
@@ -241,7 +241,7 @@ impl Default for TableBeta {
                 .highlighted_color(Color::Green)
                 .highlighted_str(">> ")
                 .row_height(1)
-                .headers(&["Key", "Msg", "Description"])
+                .headers(["Key", "Msg", "Description"])
                 .column_spacing(3)
                 .widths(&[30, 20, 50])
                 .table(

--- a/examples/textarea.rs
+++ b/examples/textarea.rs
@@ -150,7 +150,7 @@ impl Default for TextareaAlfa {
                 .title("Night Moves (Bob Seger)", Alignment::Center)
                 .step(4)
                 .highlighted_str("🎵")
-                .text_rows(&[
+                .text_rows([
                     TextSpan::new("I was a little too tall, could've used a few pounds,")
                         .underlined()
                         .fg(Color::Green),
@@ -219,7 +219,7 @@ impl Default for TextareaBeta {
                 .title("Roxanne (The Police)", Alignment::Center)
                 .step(4)
                 .highlighted_str("🎵")
-                .text_rows(&[
+                .text_rows([
                     TextSpan::new("Roxanne").underlined().fg(Color::Red),
                     TextSpan::from("You don't have to put on the red light"),
                     TextSpan::from("Those days are over"),

--- a/src/components/canvas.rs
+++ b/src/components/canvas.rs
@@ -52,11 +52,11 @@ impl Canvas {
         self
     }
 
-    pub fn data(mut self, data: &[Shape]) -> Self {
+    pub fn data(mut self, data: impl IntoIterator<Item = Shape>) -> Self {
         self.attr(
             Attribute::Shape,
             AttrValue::Payload(PropPayload::Vec(
-                data.iter().map(|x| PropValue::Shape(x.clone())).collect(),
+                data.into_iter().map(PropValue::Shape).collect(),
             )),
         );
         self
@@ -247,7 +247,7 @@ mod test {
             .marker(Marker::Dot)
             .x_bounds((-180.0, 180.0))
             .y_bounds((-90.0, 90.0))
-            .data(&[
+            .data([
                 Shape::Map(Map {
                     resolution: MapResolution::High,
                     color: Color::Rgb(240, 240, 240),

--- a/src/components/chart.rs
+++ b/src/components/chart.rs
@@ -120,11 +120,11 @@ impl Chart {
         self
     }
 
-    pub fn data(mut self, data: &[Dataset]) -> Self {
+    pub fn data(mut self, data: impl IntoIterator<Item = Dataset>) -> Self {
         self.props.set(
             Attribute::Dataset,
             AttrValue::Payload(PropPayload::Vec(
-                data.iter().cloned().map(PropValue::Dataset).collect(),
+                data.into_iter().map(PropValue::Dataset).collect(),
             )),
         );
         self
@@ -476,7 +476,7 @@ mod test {
             .y_labels(&["-5", "0", "5", "10", "15", "20", "25", "30", "35"])
             .y_style(Style::default().fg(Color::LightYellow))
             .y_title("Month")
-            .data(&[
+            .data([
                 Dataset::default()
                     .name("Minimum")
                     .graph_type(GraphType::Scatter)
@@ -544,7 +544,7 @@ mod test {
         assert_eq!(component.is_disabled(), false);
         assert_eq!(component.get_data(2).len(), 2);
 
-        let mut comp = Chart::default().data(&[Dataset::default()
+        let mut comp = Chart::default().data([Dataset::default()
             .name("Maximum")
             .graph_type(GraphType::Line)
             .marker(Marker::Dot)

--- a/src/components/checkbox.rs
+++ b/src/components/checkbox.rs
@@ -99,8 +99,8 @@ impl CheckboxStates {
     /// Set CheckboxStates choices from a vector of str
     /// In addition resets current selection and keep index if possible or set it to the first value
     /// available
-    pub fn set_choices(&mut self, choices: &[String]) {
-        self.choices = choices.to_vec();
+    pub fn set_choices(&mut self, choices: impl Into<Vec<String>>) {
+        self.choices = choices.into();
         // Clear selection
         self.selection.clear();
         // Keep index if possible
@@ -155,13 +155,13 @@ impl Checkbox {
         self
     }
 
-    pub fn choices<S: AsRef<str>>(mut self, choices: &[S]) -> Self {
+    pub fn choices<S: Into<String>>(mut self, choices: impl IntoIterator<Item = S>) -> Self {
         self.attr(
             Attribute::Content,
             AttrValue::Payload(PropPayload::Vec(
                 choices
-                    .iter()
-                    .map(|x| PropValue::Str(x.as_ref().to_string()))
+                    .into_iter()
+                    .map(|v| PropValue::Str(v.into()))
                     .collect(),
             )),
         );
@@ -268,7 +268,7 @@ impl MockComponent for Checkbox {
                     .cloned()
                     .map(|x| x.unwrap_str())
                     .collect();
-                self.states.set_choices(&choices);
+                self.states.set_choices(choices);
                 // Preserve selection if possible
                 for c in current_selection.into_iter() {
                     self.states.select(c);
@@ -411,7 +411,7 @@ mod test {
             .foreground(Color::Red)
             .borders(Borders::default())
             .title("Which food do you prefer?", Alignment::Center)
-            .choices(&["Pizza", "Hummus", "Ramen", "Gyoza", "Pasta"])
+            .choices(["Pizza", "Hummus", "Ramen", "Gyoza", "Pasta"])
             .values(&[1, 4])
             .rewind(false);
         // Verify states
@@ -501,5 +501,31 @@ mod test {
             component.perform(Cmd::Submit),
             CmdResult::Submit(State::Vec(vec![StateValue::Usize(0)])),
         );
+    }
+
+    #[test]
+    fn various_set_choice_types() {
+        // static array of strings
+        CheckboxStates::default().set_choices(&["hello".to_string()]);
+        // vector of strings
+        CheckboxStates::default().set_choices(vec!["hello".to_string()]);
+        // boxed array of strings
+        CheckboxStates::default().set_choices(vec!["hello".to_string()].into_boxed_slice());
+    }
+
+    #[test]
+    fn various_choice_types() {
+        // static array of static strings
+        let _ = Checkbox::default().choices(["hello"]);
+        // static array of strings
+        let _ = Checkbox::default().choices(["hello".to_string()]);
+        // vec of static strings
+        let _ = Checkbox::default().choices(vec!["hello"]);
+        // vec of strings
+        let _ = Checkbox::default().choices(vec!["hello".to_string()]);
+        // boxed array of static strings
+        let _ = Checkbox::default().choices(vec!["hello"].into_boxed_slice());
+        // boxed array of strings
+        let _ = Checkbox::default().choices(vec!["hello".to_string()].into_boxed_slice());
     }
 }

--- a/src/components/line_gauge.rs
+++ b/src/components/line_gauge.rs
@@ -101,8 +101,7 @@ impl LineGauge {
             LINE_GAUGE_STYLE_ROUND,
             LINE_GAUGE_STYLE_THICK,
         ]
-        .iter()
-        .any(|x| *x == s))
+        .contains(&s))
         {
             panic!("Invalid line style");
         }

--- a/src/components/paragraph.rs
+++ b/src/components/paragraph.rs
@@ -60,11 +60,13 @@ impl Paragraph {
         self
     }
 
-    pub fn text(mut self, s: &[TextSpan]) -> Self {
+    /// Set the text of the [`Paragraph`].
+    // This method takes a `IntoIterator` so that it is up to the user when a clone is necessary
+    pub fn text(mut self, s: impl IntoIterator<Item = TextSpan>) -> Self {
         self.attr(
             Attribute::Text,
             AttrValue::Payload(PropPayload::Vec(
-                s.iter().cloned().map(PropValue::TextSpan).collect(),
+                s.into_iter().map(PropValue::TextSpan).collect(),
             )),
         );
         self
@@ -182,7 +184,7 @@ mod tests {
             .foreground(Color::Red)
             .modifiers(TextModifiers::BOLD)
             .alignment(Alignment::Center)
-            .text(&[
+            .text([
                 TextSpan::from("Press "),
                 TextSpan::from("<ESC>").fg(Color::Cyan).bold(),
                 TextSpan::from(" to quit"),
@@ -191,5 +193,17 @@ mod tests {
             .title("title", Alignment::Center);
         // Get value
         assert_eq!(component.state(), State::None);
+    }
+
+    #[test]
+    fn various_text_types() {
+        // Vec
+        let _ = Paragraph::default().text(vec![TextSpan::new("hello")]);
+        // static array
+        let _ = Paragraph::default().text([TextSpan::new("hello")]);
+        // boxed array
+        let _ = Paragraph::default().text(vec![TextSpan::new("hello")].into_boxed_slice());
+        // already a iterator
+        let _ = Paragraph::default().text(["Hello"].map(TextSpan::new));
     }
 }

--- a/src/components/radio.rs
+++ b/src/components/radio.rs
@@ -73,8 +73,8 @@ impl RadioStates {
     /// Set RadioStates choices from a vector of text spans
     /// In addition resets current selection and keep index if possible or set it to the first value
     /// available
-    pub fn set_choices(&mut self, spans: &[String]) {
-        self.choices = spans.to_vec();
+    pub fn set_choices(&mut self, choices: impl Into<Vec<String>>) {
+        self.choices = choices.into();
         // Keep index if possible
         if self.choice >= self.choices.len() {
             self.choice = match self.choices.len() {
@@ -133,13 +133,13 @@ impl Radio {
         self
     }
 
-    pub fn choices<S: AsRef<str>>(mut self, choices: &[S]) -> Self {
+    pub fn choices<S: Into<String>>(mut self, choices: impl IntoIterator<Item = S>) -> Self {
         self.attr(
             Attribute::Content,
             AttrValue::Payload(PropPayload::Vec(
                 choices
-                    .iter()
-                    .map(|x| PropValue::Str(x.as_ref().to_string()))
+                    .into_iter()
+                    .map(|v| PropValue::Str(v.into()))
                     .collect(),
             )),
         );
@@ -229,7 +229,7 @@ impl MockComponent for Radio {
                     .iter()
                     .map(|x| x.clone().unwrap_str())
                     .collect();
-                self.states.set_choices(&choices);
+                self.states.set_choices(choices);
             }
             Attribute::Value => {
                 self.states
@@ -339,7 +339,7 @@ mod test {
             .foreground(Color::Red)
             .borders(Borders::default())
             .title("C'est oui ou bien c'est non?", Alignment::Center)
-            .choices(&["Oui!", "Non", "Peut-être"])
+            .choices(["Oui!", "Non", "Peut-être"])
             .value(1)
             .rewind(false);
         // Verify states
@@ -388,5 +388,31 @@ mod test {
             component.perform(Cmd::Submit),
             CmdResult::Submit(State::One(StateValue::Usize(2))),
         );
+    }
+
+    #[test]
+    fn various_set_choice_types() {
+        // static array of strings
+        RadioStates::default().set_choices(&["hello".to_string()]);
+        // vector of strings
+        RadioStates::default().set_choices(vec!["hello".to_string()]);
+        // boxed array of strings
+        RadioStates::default().set_choices(vec!["hello".to_string()].into_boxed_slice());
+    }
+
+    #[test]
+    fn various_choice_types() {
+        // static array of static strings
+        let _ = Radio::default().choices(["hello"]);
+        // static array of strings
+        let _ = Radio::default().choices(["hello".to_string()]);
+        // vec of static strings
+        let _ = Radio::default().choices(vec!["hello"]);
+        // vec of strings
+        let _ = Radio::default().choices(vec!["hello".to_string()]);
+        // boxed array of static strings
+        let _ = Radio::default().choices(vec!["hello"].into_boxed_slice());
+        // boxed array of strings
+        let _ = Radio::default().choices(vec!["hello".to_string()].into_boxed_slice());
     }
 }

--- a/src/components/select.rs
+++ b/src/components/select.rs
@@ -63,8 +63,8 @@ impl SelectStates {
     /// Set SelectStates choices from a vector of str
     /// In addition resets current selection and keep index if possible or set it to the first value
     /// available
-    pub fn set_choices(&mut self, choices: &[String]) {
-        self.choices = choices.to_vec();
+    pub fn set_choices(&mut self, choices: impl Into<Vec<String>>) {
+        self.choices = choices.into();
         // Keep index if possible
         if self.selected >= self.choices.len() {
             self.selected = match self.choices.len() {
@@ -159,13 +159,13 @@ impl Select {
         self
     }
 
-    pub fn choices<S: AsRef<str>>(mut self, choices: &[S]) -> Self {
+    pub fn choices<S: Into<String>>(mut self, choices: impl IntoIterator<Item = S>) -> Self {
         self.attr(
             Attribute::Content,
             AttrValue::Payload(PropPayload::Vec(
                 choices
-                    .iter()
-                    .map(|x| PropValue::Str(x.as_ref().to_string()))
+                    .into_iter()
+                    .map(|v| PropValue::Str(v.into()))
                     .collect(),
             )),
         );
@@ -358,7 +358,7 @@ impl MockComponent for Select {
                     .iter()
                     .map(|x| x.clone().unwrap_str())
                     .collect();
-                self.states.set_choices(&choices);
+                self.states.set_choices(choices);
             }
             Attribute::Value => {
                 self.states
@@ -444,7 +444,7 @@ mod test {
             "vanilla".to_string(),
             "chocolate".to_string(),
         ];
-        states.set_choices(&choices);
+        states.set_choices(choices);
         assert_eq!(states.selected, 0);
         assert_eq!(states.choices.len(), 4);
         // Move
@@ -473,11 +473,11 @@ mod test {
         assert_eq!(states.selected, 2);
         // Update
         let choices: &[String] = &["lemon".to_string(), "strawberry".to_string()];
-        states.set_choices(&choices);
+        states.set_choices(choices);
         assert_eq!(states.selected, 1); // Move to first index available
         assert_eq!(states.choices.len(), 2);
         let choices = vec![];
-        states.set_choices(&choices);
+        states.set_choices(choices);
         assert_eq!(states.selected, 0); // Move to first index available
         assert_eq!(states.choices.len(), 0);
         // Rewind
@@ -520,7 +520,7 @@ mod test {
             .highlighted_color(Color::Red)
             .highlighted_str(">>")
             .title("C'est oui ou bien c'est non?", Alignment::Center)
-            .choices(&["Oui!", "Non", "Peut-être"])
+            .choices(["Oui!", "Non", "Peut-être"])
             .value(1)
             .rewind(false);
         assert_eq!(component.states.is_tab_open(), false);
@@ -587,5 +587,31 @@ mod test {
             CmdResult::None
         );
         assert_eq!(component.perform(Cmd::Move(Direction::Up)), CmdResult::None);
+    }
+
+    #[test]
+    fn various_set_choice_types() {
+        // static array of strings
+        SelectStates::default().set_choices(&["hello".to_string()]);
+        // vector of strings
+        SelectStates::default().set_choices(vec!["hello".to_string()]);
+        // boxed array of strings
+        SelectStates::default().set_choices(vec!["hello".to_string()].into_boxed_slice());
+    }
+
+    #[test]
+    fn various_choice_types() {
+        // static array of static strings
+        let _ = Select::default().choices(["hello"]);
+        // static array of strings
+        let _ = Select::default().choices(["hello".to_string()]);
+        // vec of static strings
+        let _ = Select::default().choices(vec!["hello"]);
+        // vec of strings
+        let _ = Select::default().choices(vec!["hello".to_string()]);
+        // boxed array of static strings
+        let _ = Select::default().choices(vec!["hello"].into_boxed_slice());
+        // boxed array of strings
+        let _ = Select::default().choices(vec!["hello".to_string()].into_boxed_slice());
     }
 }

--- a/src/components/span.rs
+++ b/src/components/span.rs
@@ -47,11 +47,11 @@ impl Span {
         self
     }
 
-    pub fn spans(mut self, s: &[TextSpan]) -> Self {
+    pub fn spans(mut self, s: impl IntoIterator<Item = TextSpan>) -> Self {
         self.attr(
             Attribute::Text,
             AttrValue::Payload(PropPayload::Vec(
-                s.iter().cloned().map(PropValue::TextSpan).collect(),
+                s.into_iter().map(PropValue::TextSpan).collect(),
             )),
         );
         self
@@ -139,12 +139,24 @@ mod tests {
             .foreground(Color::Red)
             .modifiers(TextModifiers::BOLD)
             .alignment(Alignment::Center)
-            .spans(&[
+            .spans([
                 TextSpan::from("Press "),
                 TextSpan::from("<ESC>").fg(Color::Cyan).bold(),
                 TextSpan::from(" to quit"),
             ]);
         // Get value
         assert_eq!(component.state(), State::None);
+    }
+
+    #[test]
+    fn various_spans_types() {
+        // Vec
+        let _ = Span::default().spans(vec![TextSpan::new("hello")]);
+        // static array
+        let _ = Span::default().spans([TextSpan::new("hello")]);
+        // boxed array
+        let _ = Span::default().spans(vec![TextSpan::new("hello")].into_boxed_slice());
+        // already a iterator
+        let _ = Span::default().spans(["Hello"].map(TextSpan::new));
     }
 }

--- a/src/components/table.rs
+++ b/src/components/table.rs
@@ -195,13 +195,13 @@ impl Table {
         self
     }
 
-    pub fn headers<S: AsRef<str>>(mut self, headers: &[S]) -> Self {
+    pub fn headers<S: Into<String>>(mut self, headers: impl IntoIterator<Item = S>) -> Self {
         self.attr(
             Attribute::Text,
             AttrValue::Payload(PropPayload::Vec(
                 headers
-                    .iter()
-                    .map(|x| PropValue::Str(x.as_ref().to_string()))
+                    .into_iter()
+                    .map(|v| PropValue::Str(v.into()))
                     .collect(),
             )),
         );
@@ -563,7 +563,7 @@ mod tests {
             .column_spacing(4)
             .widths(&[25, 25, 25, 25])
             .row_height(3)
-            .headers(&["Event", "Message", "Behaviour", "???"])
+            .headers(["Event", "Message", "Behaviour", "???"])
             .table(
                 TableBuilder::default()
                     .add_col(TextSpan::from("KeyCode::Down"))
@@ -696,7 +696,7 @@ mod tests {
             .column_spacing(4)
             .widths(&[33, 33, 33])
             .row_height(3)
-            .headers(&["Event", "Message", "Behaviour"])
+            .headers(["Event", "Message", "Behaviour"])
             .table(
                 TableBuilder::default()
                     .add_col(TextSpan::from("KeyCode::Down"))
@@ -782,5 +782,21 @@ mod tests {
             AttrValue::Payload(PropPayload::One(PropValue::Usize(50))),
         );
         assert_eq!(component.states.list_index, 6);
+    }
+
+    #[test]
+    fn various_header_types() {
+        // static array of static strings
+        let _ = Table::default().headers(["hello"]);
+        // static array of strings
+        let _ = Table::default().headers(["hello".to_string()]);
+        // vec of static strings
+        let _ = Table::default().headers(vec!["hello"]);
+        // vec of strings
+        let _ = Table::default().headers(vec!["hello".to_string()]);
+        // boxed array of static strings
+        let _ = Table::default().headers(vec!["hello"].into_boxed_slice());
+        // boxed array of strings
+        let _ = Table::default().headers(vec!["hello".to_string()].into_boxed_slice());
     }
 }

--- a/src/components/textarea.rs
+++ b/src/components/textarea.rs
@@ -163,14 +163,10 @@ impl Textarea {
         self
     }
 
-    pub fn text_rows(mut self, rows: &[TextSpan]) -> Self {
+    pub fn text_rows(mut self, s: impl IntoIterator<Item = TextSpan>) -> Self {
+        let rows: Vec<PropValue> = s.into_iter().map(PropValue::TextSpan).collect();
         self.states.set_list_len(rows.len());
-        self.attr(
-            Attribute::Text,
-            AttrValue::Payload(PropPayload::Vec(
-                rows.iter().cloned().map(PropValue::TextSpan).collect(),
-            )),
-        );
+        self.attr(Attribute::Text, AttrValue::Payload(PropPayload::Vec(rows)));
         self
     }
 }
@@ -330,7 +326,7 @@ mod tests {
             .highlighted_str("🚀")
             .step(4)
             .title("textarea", Alignment::Center)
-            .text_rows(&[TextSpan::from("welcome to "), TextSpan::from("tui-realm")]);
+            .text_rows([TextSpan::from("welcome to "), TextSpan::from("tui-realm")]);
         // Increment list index
         component.states.list_index += 1;
         assert_eq!(component.states.list_index, 1);
@@ -385,5 +381,17 @@ mod tests {
         assert_eq!(component.states.list_index, 0);
         // On key
         assert_eq!(component.perform(Cmd::Delete), CmdResult::None);
+    }
+
+    #[test]
+    fn various_textrows_types() {
+        // Vec
+        let _ = Textarea::default().text_rows(vec![TextSpan::new("hello")]);
+        // static array
+        let _ = Textarea::default().text_rows([TextSpan::new("hello")]);
+        // boxed array
+        let _ = Textarea::default().text_rows(vec![TextSpan::new("hello")].into_boxed_slice());
+        // already a iterator
+        let _ = Textarea::default().text_rows(["Hello"].map(TextSpan::new));
     }
 }


### PR DESCRIPTION
# ISSUE _NUMBER_ - PULL_REQUEST_TITLE

None

## Description

This PR avoids more clones by changing parameters to take a `IntoIterator<Item = T>`/`Into<Vec<T>>` and so make it up to the user if a clone is necessary.
Due to this change, changes are likely required everywhere due to previously requiring a reference (`&`).

## Type of change

Please select relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no new *C-bindings*
- [x] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit
