### PR TITLE
Remove remaing stores of `hg_str`

### DIFF
--- a/src/components/list.rs
+++ b/src/components/list.rs
@@ -119,7 +119,6 @@ impl ListStates {
 pub struct List {
     props: Props,
     pub states: ListStates,
-    hg_str: Option<String>, // CRAP CRAP CRAP. Thanks to the author of tui-realm for using references every f time
 }
 
 impl List {
@@ -287,11 +286,11 @@ impl MockComponent for List {
                 );
             }
             // Highlighted symbol
-            self.hg_str = self
+            let hg_str = self
                 .props
-                .get(Attribute::HighlightedStr)
-                .map(|x| x.unwrap_string());
-            if let Some(hg_str) = &self.hg_str {
+                .get_ref(Attribute::HighlightedStr)
+                .and_then(|x| x.as_string());
+            if let Some(hg_str) = hg_str {
                 list = list.highlight_symbol(hg_str);
             }
             if self.scrollable() {

--- a/src/components/select.rs
+++ b/src/components/select.rs
@@ -117,7 +117,6 @@ impl SelectStates {
 pub struct Select {
     props: Props,
     pub states: SelectStates,
-    hg_str: Option<String>, // CRAP CRAP CRAP
 }
 
 impl Select {
@@ -269,11 +268,11 @@ impl Select {
                     .add_modifier(TextModifiers::REVERSED),
             );
         // Highlighted symbol
-        self.hg_str = self
+        let hg_str = self
             .props
-            .get(Attribute::HighlightedStr)
-            .map(|x| x.unwrap_string());
-        if let Some(hg_str) = &self.hg_str {
+            .get_ref(Attribute::HighlightedStr)
+            .and_then(|x| x.as_string());
+        if let Some(hg_str) = hg_str {
             list = list.highlight_symbol(hg_str);
         }
         let mut state: ListState = ListState::default();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -224,17 +224,12 @@ mod test {
 
     #[test]
     fn test_components_utils_get_block() {
-        let props = Borders::default()
+        let borders = Borders::default()
             .sides(BorderSides::ALL)
             .color(Color::Red)
             .modifiers(BorderType::Rounded);
-        let _ = get_block(
-            props.clone(),
-            Some(&("title", Alignment::Center)),
-            true,
-            None,
-        );
-        let _ = get_block::<&str>(props, None, false, None);
+        let _ = get_block(borders, Some(&("title", Alignment::Center)), true, None);
+        let _ = get_block::<&str>(borders, None, false, None);
     }
 
     #[test]


### PR DESCRIPTION
# ISSUE _NUMBER_ - PULL_REQUEST_TITLE

None

## Description

This PR removes the remaining 2 places where `hg_str` was stored as a state, where it was fetched freshly anyway.
This also removes all remaining `// CRAP CRAP CRAP` comments.

Additionally, fix a clippy warning.

## Type of change

Please select relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no new *C-bindings*
- [x] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit
