### PR TITLE
fix(input): limit cursor positon to input area

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@
 
 ---
 
+## next
+
+Unreleased
+
+- [Issue 35](https://github.com/veeso/tui-realm-stdlib/issues/35): dont let the `Input`'s cursor escape the component's area
+
 ## 3.0.0
 
 Released on 07/06/2025

--- a/src/components/input.rs
+++ b/src/components/input.rs
@@ -302,8 +302,11 @@ impl MockComponent for Input {
                     + calc_utf8_cursor_position(
                         &self.states.render_value_chars(itype)[0..self.states.cursor],
                     );
-                render
-                    .set_cursor_position(tuirealm::ratatui::prelude::Position { x, y: area.y + 1 });
+                let x = x.min(block_inner_area.x + block_inner_area.width);
+                render.set_cursor_position(tuirealm::ratatui::prelude::Position {
+                    x,
+                    y: block_inner_area.y,
+                });
             }
         }
     }


### PR DESCRIPTION
# ISSUE _NUMBER_ - PULL_REQUEST_TITLE

re #35

## Description

This PR limit's the `Input`s cursor the input area's area.
Note that it will still flow into the outer block's border on overflow, but not beyond that, it think that is better than staying on the last character and not knowing the cursor is beyond that point.

## Type of change

Please select relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no new *C-bindings*
- [x] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit
