### PR TITLE
style(utils): remove stray backtick

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,6 @@
 //! ## Utils
 //!
-//! `Utilities functions to work with components
+//! Utilities functions to work with components
 
 // deps
 extern crate textwrap;


### PR DESCRIPTION
# ISSUE _NUMBER_ - PULL_REQUEST_TITLE

None

## Description

Only what the titles says, removes a stray backtick in the `utils.rs` description

## Type of change

Please select relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no new *C-bindings*
- [x] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit
