### PR TITLE
Manual Spinner stepping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,13 @@
 
 ---
 
+## next
+
+Unreleased
+
+- Add option `view_auto_step` to `Spinner` to disable automatic sequence stepping in a `view` call.
+  - Add function `manual_step` to `Spinner` to set option `view_auto_step` in a builder-like fashion.
+
 ## 3.0.0
 
 Released on 07/06/2025

--- a/examples/spinner.rs
+++ b/examples/spinner.rs
@@ -13,6 +13,7 @@ use tuirealm::{
     application::PollStrategy,
     event::{Key, KeyEvent},
 };
+use tuirealm::{Sub, SubClause, SubEventClause};
 // tui
 use tuirealm::ratatui::layout::{Constraint, Direction as LayoutDirection, Layout};
 
@@ -41,7 +42,9 @@ impl Default for Model {
     fn default() -> Self {
         // Setup app
         let mut app: Application<Id, Msg, NoUserEvent> = Application::init(
-            EventListenerCfg::default().crossterm_input_listener(Duration::from_millis(10), 10),
+            EventListenerCfg::default()
+                .crossterm_input_listener(Duration::from_millis(10), 10)
+                .tick_interval(Duration::from_millis(500)),
         );
         assert!(
             app.mount(Id::SpanAlfa, Box::new(SpanAlfa::default()), vec![])
@@ -52,8 +55,12 @@ impl Default for Model {
                 .is_ok()
         );
         assert!(
-            app.mount(Id::SpinnerAlfa, Box::new(SpinnerAlfa::default()), vec![])
-                .is_ok()
+            app.mount(
+                Id::SpinnerAlfa,
+                Box::new(SpinnerAlfa::default()),
+                vec![Sub::new(SubEventClause::Tick, SubClause::Always)]
+            )
+            .is_ok()
         );
         assert!(
             app.mount(Id::SpinnerBeta, Box::new(SpinnerBeta::default()), vec![])
@@ -214,13 +221,18 @@ impl Default for SpinnerAlfa {
         Self {
             component: Spinner::default()
                 .foreground(Color::LightBlue)
-                .sequence("⣾⣽⣻⢿⡿⣟⣯⣷"),
+                .sequence("⣾⣽⣻⢿⡿⣟⣯⣷")
+                .manual_step(),
         }
     }
 }
 
 impl Component<Msg, NoUserEvent> for SpinnerAlfa {
-    fn on(&mut self, _: Event<NoUserEvent>) -> Option<Msg> {
+    fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
+        if ev == Event::Tick {
+            self.component.states.step();
+        }
+
         None
     }
 }

--- a/src/components/spinner.rs
+++ b/src/components/spinner.rs
@@ -42,6 +42,13 @@ impl SpinnerStates {
         }
         ch
     }
+
+    /// Get the current char to display
+    ///
+    /// Unlike [`step`](Self::step), this function does not increment the step.
+    pub fn current_step(&self) -> char {
+        self.sequence.get(self.step).copied().unwrap_or(' ')
+    }
 }
 
 // -- Component
@@ -49,11 +56,24 @@ impl SpinnerStates {
 /// ## Spinner
 ///
 /// A textual spinner which step changes at each `view()` call
-#[derive(Default)]
 #[must_use]
 pub struct Spinner {
     props: Props,
     pub states: SpinnerStates,
+    /// Automatically call [`SpinnerStates::step`] in [`view`](Spinner::view).
+    ///
+    /// This option might be removed in a future major version
+    pub view_auto_step: bool,
+}
+
+impl Default for Spinner {
+    fn default() -> Self {
+        Self {
+            props: Default::default(),
+            states: Default::default(),
+            view_auto_step: true,
+        }
+    }
 }
 
 impl Spinner {
@@ -69,6 +89,12 @@ impl Spinner {
 
     pub fn sequence<S: Into<String>>(mut self, s: S) -> Self {
         self.attr(Attribute::Text, AttrValue::String(s.into()));
+        self
+    }
+
+    /// Dont automatically step the sequence in a [`view`](Self::view) call
+    pub fn manual_step(mut self) -> Self {
+        self.view_auto_step = false;
         self
     }
 }
@@ -87,7 +113,12 @@ impl MockComponent for Spinner {
                 .get_or(Attribute::Background, AttrValue::Color(Color::Reset))
                 .unwrap_color();
             // Get text
-            let text: Text = Text::from(Spans::from(TuiSpan::from(self.states.step().to_string())));
+            let seq_char = if self.view_auto_step {
+                self.states.step()
+            } else {
+                self.states.current_step()
+            };
+            let text: Text = Text::from(Spans::from(TuiSpan::from(seq_char.to_string())));
             render.render_widget(
                 Paragraph::new(text)
                     .alignment(Alignment::Left)
@@ -125,6 +156,7 @@ mod tests {
     use super::*;
 
     use pretty_assertions::assert_eq;
+    use tuirealm::ratatui::{self};
 
     #[test]
     fn test_components_span() {
@@ -134,5 +166,80 @@ mod tests {
             .sequence("⣾⣽⣻⢿⡿⣟⣯⣷");
         // Get value
         assert_eq!(component.state(), State::None);
+    }
+
+    #[test]
+    fn should_step_in_view() {
+        let mut component = Spinner::default().sequence("123");
+
+        assert_eq!(component.states.step, 0);
+
+        let mut terminal =
+            ratatui::Terminal::new(ratatui::backend::TestBackend::new(16, 16)).unwrap();
+
+        terminal
+            .draw(|f| {
+                component.view(f, f.area());
+                assert_eq!(component.states.step, 1);
+            })
+            .unwrap();
+
+        terminal
+            .draw(|f| {
+                component.view(f, f.area());
+                assert_eq!(component.states.step, 2);
+            })
+            .unwrap();
+
+        terminal
+            .draw(|f| {
+                component.view(f, f.area());
+                assert_eq!(component.states.step, 0);
+            })
+            .unwrap();
+    }
+
+    #[test]
+    fn should_not_step_in_view() {
+        let mut component = Spinner::default().sequence("123").manual_step();
+
+        assert_eq!(component.states.step, 0);
+
+        let mut terminal =
+            ratatui::Terminal::new(ratatui::backend::TestBackend::new(16, 16)).unwrap();
+
+        terminal
+            .draw(|f| {
+                component.view(f, f.area());
+                assert_eq!(component.states.step, 0);
+            })
+            .unwrap();
+
+        component.states.step();
+
+        terminal
+            .draw(|f| {
+                component.view(f, f.area());
+                assert_eq!(component.states.step, 1);
+            })
+            .unwrap();
+
+        component.states.step();
+
+        terminal
+            .draw(|f| {
+                component.view(f, f.area());
+                assert_eq!(component.states.step, 2);
+            })
+            .unwrap();
+
+        component.states.step();
+
+        terminal
+            .draw(|f| {
+                component.view(f, f.area());
+                assert_eq!(component.states.step, 0);
+            })
+            .unwrap();
     }
 }


### PR DESCRIPTION
# ISSUE _NUMBER_ - PULL_REQUEST_TITLE

No issue

## Description

This PR adds a option to disable the automatic stepping of a spinner in a `view` call. This is necessary as i have found that `view` calls can be inconsistent (ex many keyboard inputs result in a view each vs idle ticker every X milliseconds), making the appearance of the Spinner inconsistent.

List here your changes

- Add option `view_auto_step` to enable / disable automatic stepping in `view` call (enabled by default to maintain backwards compat)
- Adjusted example for `spinner` to have one be based on manual stepping

## Type of change

Please select relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no new *C-bindings*
- [x] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit

---

PS: in the future, the manual stepping might be made the default instead and / or completely remove the option and always require manual stepping. (if this is not the case, the comment about this should likely be removed)