### PR TITLE
style: fix clippy warnings new with rust 1.89

### DIFF
--- a/src/components/chart.rs
+++ b/src/components/chart.rs
@@ -231,7 +231,7 @@ impl Chart {
     /// ### data
     ///
     /// Get data to be displayed, starting from provided index at `start`
-    fn get_data(&mut self, start: usize) -> Vec<TuiDataset> {
+    fn get_data(&mut self, start: usize) -> Vec<TuiDataset<'_>> {
         self.states.data = self
             .props
             .get(Attribute::Dataset)

--- a/src/components/table.rs
+++ b/src/components/table.rs
@@ -272,7 +272,7 @@ impl Table {
     }
 
     /// Generate [`Row`]s from a 2d vector of [`TextSpan`](tuirealm::props::TextSpan)s in props [`Attribute::Content`].
-    fn make_rows(&self, row_height: u16) -> Vec<Row> {
+    fn make_rows(&self, row_height: u16) -> Vec<Row<'_>> {
         let Some(table) = self
             .props
             .get_ref(Attribute::Content)

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -117,7 +117,7 @@ pub fn get_block<T: AsRef<str>>(
     title: Option<&(T, Alignment)>,
     focus: bool,
     inactive_style: Option<Style>,
-) -> Block {
+) -> Block<'_> {
     let title = title.map_or(("", Alignment::Left), |v| (v.0.as_ref(), v.1));
     Block::default()
         .borders(props.sides)


### PR DESCRIPTION
# ISSUE _NUMBER_ - PULL_REQUEST_TITLE

No Issue

## Description

About hiding elided lifetimes.

## Type of change

Please select relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no new *C-bindings*
- [x] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit
