### PR TITLE
Smoother ProgressBars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@
 
 ---
 
+## next
+
+Unreleased
+
+- Change `ProgressBar` to enable ratatui Gauge option `use_unicode` for smoother progressbars.
+
 ## 3.0.0
 
 Released on 07/06/2025

--- a/examples/progress_bar.rs
+++ b/examples/progress_bar.rs
@@ -7,7 +7,7 @@ use utils::Loader;
 
 use std::time::Duration;
 
-use tui_realm_stdlib::ProgressBar;
+use tui_realm_stdlib::{Label, ProgressBar};
 use tuirealm::command::CmdResult;
 use tuirealm::listener::{ListenerResult, Poll};
 use tuirealm::props::{
@@ -33,6 +33,7 @@ pub enum Msg {
 // Let's define the component ids for our application
 #[derive(Debug, Eq, PartialEq, Clone, Hash)]
 pub enum Id {
+    Label,
     GaugeAlfa,
     GaugeBeta,
 }
@@ -57,6 +58,10 @@ impl Default for Model {
             EventListenerCfg::default()
                 .crossterm_input_listener(Duration::from_millis(10), 10)
                 .add_port(Box::new(Loader::default()), Duration::from_millis(50), 1),
+        );
+        assert!(
+            app.mount(Id::Label, Box::new(KeyboardLabel::default()), vec![])
+                .is_ok()
         );
         assert!(
             app.mount(Id::GaugeAlfa, Box::new(GaugeAlfa::default()), vec![])
@@ -85,6 +90,7 @@ impl Model {
                 .margin(1)
                 .constraints(
                     [
+                        Constraint::Length(1),
                         Constraint::Length(3),
                         Constraint::Length(3),
                         Constraint::Length(1),
@@ -92,8 +98,10 @@ impl Model {
                     .as_ref(),
                 )
                 .split(f.area());
-            self.app.view(&Id::GaugeAlfa, f, chunks[0]);
-            self.app.view(&Id::GaugeBeta, f, chunks[1]);
+
+            self.app.view(&Id::Label, f, chunks[0]);
+            self.app.view(&Id::GaugeAlfa, f, chunks[1]);
+            self.app.view(&Id::GaugeBeta, f, chunks[2]);
         });
     }
 }
@@ -161,6 +169,25 @@ impl Poll<UserEvent> for Loader {
 // -- components
 
 #[derive(MockComponent)]
+struct KeyboardLabel {
+    component: Label,
+}
+
+impl Default for KeyboardLabel {
+    fn default() -> Self {
+        Self {
+            component: Label::default().text("Press <TAB> to switch between bars; <ESC> to exit"),
+        }
+    }
+}
+
+impl Component<Msg, UserEvent> for KeyboardLabel {
+    fn on(&mut self, _: Event<UserEvent>) -> Option<Msg> {
+        None
+    }
+}
+
+#[derive(MockComponent)]
 struct GaugeAlfa {
     component: ProgressBar,
 }
@@ -176,7 +203,7 @@ impl Default for GaugeAlfa {
                 )
                 .foreground(Color::Green)
                 .label("0%")
-                .title("Loading...", Alignment::Center)
+                .title("Fast Loading...", Alignment::Center)
                 .progress(0.0),
         }
     }
@@ -219,7 +246,7 @@ impl Default for GaugeBeta {
                 )
                 .foreground(Color::Yellow)
                 .label("0%")
-                .title("Loading...", Alignment::Center)
+                .title("Slow Loading...", Alignment::Center)
                 .progress(0.0),
         }
     }
@@ -228,7 +255,16 @@ impl Default for GaugeBeta {
 impl Component<Msg, UserEvent> for GaugeBeta {
     fn on(&mut self, ev: Event<UserEvent>) -> Option<Msg> {
         let _ = match ev {
-            Event::User(UserEvent::Loaded(prog)) => {
+            Event::User(UserEvent::Loaded(_)) => {
+                let mut prog = self
+                    .query(Attribute::Value)
+                    .as_ref()
+                    .and_then(AttrValue::as_payload)
+                    .and_then(PropPayload::as_one)
+                    .and_then(PropValue::as_f64)
+                    .unwrap_or_default();
+                prog += 0.001f64;
+
                 // Update
                 let label = format!("{:02}%", (prog * 100.0) as usize);
                 self.attr(

--- a/src/components/progress_bar.rs
+++ b/src/components/progress_bar.rs
@@ -123,7 +123,8 @@ impl MockComponent for ProgressBar {
                             .add_modifier(modifiers),
                     )
                     .label(label)
-                    .ratio(percentage),
+                    .ratio(percentage)
+                    .use_unicode(true),
                 area,
             );
         }


### PR DESCRIPTION
# ISSUE _NUMBER_ - PULL_REQUEST_TITLE

No issue

## Description

This PR makes use of ratatui's [`Gauge::use_unicode`](https://docs.rs/ratatui/latest/ratatui/widgets/struct.Gauge.html#method.use_unicode) to have smoother bars instead of only full-blocks.

List here your changes

- always enable `use_unicode` for any `Progressbar`
- change progress bar example to have a fast & slow bar, best showcasing why it is useful
  - also add keyboard shortcut text to the example

PS: i only just got to know about the ratatui option existing

## Type of change

Please select relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no new *C-bindings*
- [x] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit
