### PR TITLE
Fixup to help builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ Cargo.lock
 
 # Macos
 .DS_Store
+.idea
+

--- a/src/components/select.rs
+++ b/src/components/select.rs
@@ -209,7 +209,7 @@ impl Select {
         let chunks = Layout::default()
             .direction(LayoutDirection::Vertical)
             .margin(0)
-            .constraints([Constraint::Length(2), Constraint::Min(1)].as_ref())
+            .constraints(&[Constraint::Length(2), Constraint::Min(1)])
             .split(area);
         // Render like "closed" tab in chunk 0
         let selected_text: String = match self.states.choices.get(self.states.selected) {


### PR DESCRIPTION
(I didn't create an issue for it)

## Description

Change `.as_ref()` to `&` to avoid type confusion.
Here is an example project permalink that will fail without this change, but works with the change
https://github.com/phughk/liars-dice-rs/tree/6d6ee2631fed6105ea00768846ae2ba3e4565c38/liars-dice-ratatui

## Type of change

Please select relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no new *C-bindings*
- [x] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit
