### PR TITLE
Fix Styling inconsistencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@
 
 ---
 
+## next
+
+Unreleased
+
+- Fix a bunch of styling inconsistencies. (re #43)
+
 ## 3.0.0
 
 Released on 07/06/2025

--- a/examples/table.rs
+++ b/examples/table.rs
@@ -70,7 +70,7 @@ impl Model {
                 .margin(1)
                 .constraints(
                     [
-                        Constraint::Length(10),
+                        Constraint::Length(15),
                         Constraint::Length(6),
                         Constraint::Length(1),
                     ]
@@ -148,6 +148,8 @@ impl Default for TableAlfa {
                         .modifiers(BorderType::Thick)
                         .color(Color::Yellow),
                 )
+                .foreground(Color::Yellow)
+                .background(Color::Black)
                 .title("Keybindings", Alignment::Center)
                 .scroll(true)
                 .highlighted_color(Color::LightYellow)
@@ -238,6 +240,7 @@ impl Default for TableBeta {
                         .color(Color::Green),
                 )
                 .foreground(Color::Green)
+                .background(Color::Gray)
                 .title("Keybindings (not scrollable)", Alignment::Center)
                 .scroll(false)
                 .highlighted_color(Color::Green)

--- a/src/components/bar_chart.rs
+++ b/src/components/bar_chart.rs
@@ -244,8 +244,8 @@ impl MockComponent for BarChart {
                 .get(Attribute::FocusStyle)
                 .map(|x| x.unwrap_style());
             let active: bool = if self.is_disabled() { true } else { focus };
-            let mut div = crate::utils::get_block(borders, title, active, inactive_style);
-            div = div.style(Style::default().bg(background).fg(foreground));
+            let normal_style = Style::default().bg(background).fg(foreground);
+            let div = crate::utils::get_block(borders, title, active, inactive_style);
             // Get max elements
             let data_max_len = self
                 .props
@@ -255,8 +255,10 @@ impl MockComponent for BarChart {
             let data = self.get_data(self.states.cursor, data_max_len);
             let data_ref: Vec<(&str, u64)> = data.iter().map(|x| (x.0.as_str(), x.1)).collect();
             // Create widget
-            let mut widget: TuiBarChart =
-                TuiBarChart::default().block(div).data(data_ref.as_slice());
+            let mut widget: TuiBarChart = TuiBarChart::default()
+                .style(normal_style)
+                .block(div)
+                .data(data_ref.as_slice());
             if let Some(gap) = self
                 .props
                 .get(Attribute::Custom(BAR_CHART_BARS_GAP))

--- a/src/components/canvas.rs
+++ b/src/components/canvas.rs
@@ -33,6 +33,10 @@ pub struct Canvas {
 }
 
 impl Canvas {
+    /// Note that setting this value has no effect.
+    ///
+    /// If you want to set the border color, use [`borders`](Self::borders).
+    /// If you want to set some point in the canvas, set it in the data.
     pub fn foreground(mut self, fg: Color) -> Self {
         self.attr(Attribute::Foreground, AttrValue::Color(fg));
         self
@@ -153,10 +157,10 @@ impl Canvas {
 impl MockComponent for Canvas {
     fn view(&mut self, render: &mut Frame, area: Rect) {
         if self.props.get_or(Attribute::Display, AttrValue::Flag(true)) == AttrValue::Flag(true) {
-            let foreground = self
-                .props
-                .get_or(Attribute::Foreground, AttrValue::Color(Color::Reset))
-                .unwrap_color();
+            // let foreground = self
+            //     .props
+            //     .get_or(Attribute::Foreground, AttrValue::Color(Color::Reset))
+            //     .unwrap_color();
             let background = self
                 .props
                 .get_or(Attribute::Background, AttrValue::Color(Color::Reset))
@@ -173,8 +177,7 @@ impl MockComponent for Canvas {
                 .props
                 .get_or(Attribute::Focus, AttrValue::Flag(false))
                 .unwrap_flag();
-            let mut block = crate::utils::get_block(borders, title, focus, None);
-            block = block.style(Style::default().bg(background).fg(foreground));
+            let block = crate::utils::get_block(borders, title, focus, None);
             // Get properties
             let x_bounds: [f64; 2] = self
                 .props

--- a/src/components/chart.rs
+++ b/src/components/chart.rs
@@ -298,6 +298,7 @@ impl MockComponent for Chart {
                 .props
                 .get(Attribute::FocusStyle)
                 .map(|x| x.unwrap_style());
+            let normal_style = Style::default().fg(foreground).bg(background);
             let active: bool = if self.is_disabled() { true } else { focus };
             let div = crate::utils::get_block(borders, title.as_ref(), active, inactive_style);
             // Create widget
@@ -330,10 +331,7 @@ impl MockComponent for Chart {
                 .get(Attribute::Custom(CHART_X_TITLE))
                 .map(|x| x.unwrap_string())
             {
-                x_axis = x_axis.title(Span::styled(
-                    title,
-                    Style::default().fg(foreground).bg(background),
-                ));
+                x_axis = x_axis.title(Span::styled(title, normal_style));
             }
             // -- y axis
             let mut y_axis: Axis = Axis::default();
@@ -364,15 +362,16 @@ impl MockComponent for Chart {
                 .get(Attribute::Custom(CHART_Y_TITLE))
                 .map(|x| x.unwrap_string())
             {
-                y_axis = y_axis.title(Span::styled(
-                    title,
-                    Style::default().fg(foreground).bg(background),
-                ));
+                y_axis = y_axis.title(Span::styled(title, normal_style));
             }
             // Get data
             let data: Vec<TuiDataset> = self.get_data(self.states.cursor);
             // Build widget
-            let widget: TuiChart = TuiChart::new(data).block(div).x_axis(x_axis).y_axis(y_axis);
+            let widget: TuiChart = TuiChart::new(data)
+                .style(normal_style)
+                .block(div)
+                .x_axis(x_axis)
+                .y_axis(y_axis);
             // Render
             render.render_widget(widget, area);
         }

--- a/src/components/checkbox.rs
+++ b/src/components/checkbox.rs
@@ -28,6 +28,7 @@
 use tuirealm::command::{Cmd, CmdResult, Direction};
 use tuirealm::props::{
     Alignment, AttrValue, Attribute, Borders, Color, PropPayload, PropValue, Props, Style,
+    TextModifiers,
 };
 use tuirealm::ratatui::text::Line as Spans;
 use tuirealm::ratatui::{layout::Rect, text::Span, widgets::Tabs};
@@ -215,12 +216,10 @@ impl MockComponent for Checkbox {
                 .props
                 .get(Attribute::FocusStyle)
                 .map(|x| x.unwrap_style());
+
+            let normal_style = Style::default().fg(foreground).bg(background);
+
             let div = crate::utils::get_block(borders, title, focus, inactive_style);
-            // Make colors
-            let (bg, fg, block_color): (Color, Color, Color) = match &focus {
-                true => (foreground, background, foreground),
-                false => (Color::Reset, foreground, Color::Reset),
-            };
             // Make choices
             let choices: Vec<Spans> = self
                 .states
@@ -229,26 +228,20 @@ impl MockComponent for Checkbox {
                 .enumerate()
                 .map(|(idx, x)| {
                     let checkbox: &str = if self.states.has(idx) { "☑ " } else { "☐ " };
-                    let (fg, bg) = if focus {
-                        if self.states.choice == idx {
-                            (fg, bg)
-                        } else {
-                            (bg, fg)
-                        }
-                    } else {
-                        (fg, bg)
-                    };
                     // Make spans
-                    Spans::from(vec![
-                        Span::styled(checkbox, Style::default().fg(fg).bg(bg)),
-                        Span::styled(x.to_string(), Style::default().fg(fg).bg(bg)),
-                    ])
+                    Spans::from(vec![Span::raw(checkbox), Span::raw(x.to_string())])
                 })
                 .collect();
             let checkbox: Tabs = Tabs::new(choices)
                 .block(div)
                 .select(self.states.choice)
-                .style(Style::default().fg(block_color));
+                .style(normal_style)
+                .highlight_style(Style::default().fg(foreground).add_modifier(if focus {
+                    TextModifiers::REVERSED
+                } else {
+                    TextModifiers::empty()
+                }));
+
             render.render_widget(checkbox, area);
         }
     }

--- a/src/components/line_gauge.rs
+++ b/src/components/line_gauge.rs
@@ -158,17 +158,19 @@ impl MockComponent for LineGauge {
                 .unwrap_payload()
                 .unwrap_one()
                 .unwrap_f64();
+
+            let normal_style = Style::default()
+                .fg(foreground)
+                .bg(background)
+                .add_modifier(modifiers);
+
             let div = crate::utils::get_block(borders, title, true, None);
             // Make progress bar
             render.render_widget(
                 TuiLineGauge::default()
                     .block(div)
-                    .filled_style(
-                        Style::default()
-                            .fg(foreground)
-                            .bg(background)
-                            .add_modifier(modifiers),
-                    )
+                    .style(normal_style)
+                    .filled_style(normal_style)
                     .line_set(self.line_set())
                     .label(label)
                     .ratio(percentage),

--- a/src/components/progress_bar.rs
+++ b/src/components/progress_bar.rs
@@ -111,17 +111,19 @@ impl MockComponent for ProgressBar {
                 .unwrap_payload()
                 .unwrap_one()
                 .unwrap_f64();
+
+            let normal_style = Style::default()
+                .fg(foreground)
+                .bg(background)
+                .add_modifier(modifiers);
+
             let div = crate::utils::get_block(borders, title, true, None);
             // Make progress bar
             render.render_widget(
                 Gauge::default()
                     .block(div)
-                    .gauge_style(
-                        Style::default()
-                            .fg(foreground)
-                            .bg(background)
-                            .add_modifier(modifiers),
-                    )
+                    .style(normal_style)
+                    .gauge_style(normal_style)
                     .label(label)
                     .ratio(percentage),
                 area,

--- a/src/components/radio.rs
+++ b/src/components/radio.rs
@@ -197,23 +197,19 @@ impl MockComponent for Radio {
                 .props
                 .get(Attribute::FocusStyle)
                 .map(|x| x.unwrap_style());
+
+            let normal_style = Style::default().fg(foreground).bg(background);
+
             let div = crate::utils::get_block(borders, title, focus, inactive_style);
-            // Make colors
-            let (fg, block_color): (Color, Color) = if focus {
-                (foreground, foreground)
-            } else {
-                (foreground, Color::Reset)
-            };
-            let modifiers = if focus {
-                TextModifiers::REVERSED
-            } else {
-                TextModifiers::empty()
-            };
             let radio: Tabs = Tabs::new(choices)
                 .block(div)
                 .select(self.states.choice)
-                .style(Style::default().fg(block_color).bg(background))
-                .highlight_style(Style::default().fg(fg).add_modifier(modifiers));
+                .style(normal_style)
+                .highlight_style(Style::default().fg(foreground).add_modifier(if focus {
+                    TextModifiers::REVERSED
+                } else {
+                    TextModifiers::empty()
+                }));
             render.render_widget(radio, area);
         }
     }

--- a/src/components/select.rs
+++ b/src/components/select.rs
@@ -11,7 +11,7 @@ use tuirealm::props::{
 use tuirealm::ratatui::text::Line as Spans;
 use tuirealm::ratatui::{
     layout::{Constraint, Direction as LayoutDirection, Layout, Rect},
-    widgets::{Block, List, ListItem, ListState, Paragraph},
+    widgets::{List, ListItem, ListState, Paragraph},
 };
 use tuirealm::{Frame, MockComponent, State, StateValue};
 
@@ -216,20 +216,6 @@ impl Select {
             None => String::default(),
             Some(s) => s.clone(),
         };
-        let borders = self
-            .props
-            .get_or(Attribute::Borders, AttrValue::Borders(Borders::default()))
-            .unwrap_borders();
-        let block: Block = Block::default()
-            .borders(BorderSides::LEFT | BorderSides::TOP | BorderSides::RIGHT)
-            .border_style(borders.style())
-            .border_type(borders.modifiers)
-            .style(Style::default().bg(background));
-        let title = self.props.get(Attribute::Title).map(|x| x.unwrap_title());
-        let block = match title {
-            Some((text, alignment)) => block.title(text).title_alignment(alignment),
-            None => block,
-        };
         let focus = self
             .props
             .get_or(Attribute::Focus, AttrValue::Flag(false))
@@ -238,30 +224,33 @@ impl Select {
             .props
             .get(Attribute::FocusStyle)
             .map(|x| x.unwrap_style());
+
+        let normal_style = Style::default().bg(background).fg(foreground);
+
+        let borders = self
+            .props
+            .get_or(Attribute::Borders, AttrValue::Borders(Borders::default()))
+            .unwrap_borders();
+        let title = self
+            .props
+            .get_ref(Attribute::Title)
+            .and_then(|x| x.as_title());
+        let block_a = crate::utils::get_block(borders, title, focus, inactive_style)
+            .borders(BorderSides::LEFT | BorderSides::TOP | BorderSides::RIGHT);
+        let block_b = crate::utils::get_block::<&str>(borders, None, focus, inactive_style)
+            .borders(BorderSides::LEFT | BorderSides::BOTTOM | BorderSides::RIGHT);
+
         let p: Paragraph = Paragraph::new(selected_text)
-            .style(if focus {
-                borders.style()
-            } else {
-                inactive_style.unwrap_or_default()
-            })
-            .block(block);
+            .style(normal_style)
+            .block(block_a);
         render.render_widget(p, chunks[0]);
+
         // Render the list of elements in chunks [1]
         // Make list
         let mut list = List::new(choices)
-            .block(
-                Block::default()
-                    .borders(BorderSides::LEFT | BorderSides::BOTTOM | BorderSides::RIGHT)
-                    .border_style(if focus {
-                        borders.style()
-                    } else {
-                        Style::default()
-                    })
-                    .border_type(borders.modifiers)
-                    .style(Style::default().bg(background)),
-            )
+            .block(block_b)
             .direction(tuirealm::ratatui::widgets::ListDirection::TopToBottom)
-            .style(Style::default().fg(foreground).bg(background))
+            .style(normal_style)
             .highlight_style(
                 Style::default()
                     .fg(hg)
@@ -300,35 +289,26 @@ impl Select {
             .props
             .get_or(Attribute::Focus, AttrValue::Flag(false))
             .unwrap_flag();
-        let style = if focus {
-            Style::default().bg(background).fg(foreground)
-        } else {
-            inactive_style.unwrap_or_default()
-        };
+
+        let normal_style = Style::default().bg(background).fg(foreground);
+
         let borders = self
             .props
             .get_or(Attribute::Borders, AttrValue::Borders(Borders::default()))
             .unwrap_borders();
-        let borders_style = if focus {
-            borders.style()
-        } else {
-            inactive_style.unwrap_or_default()
-        };
-        let block: Block = Block::default()
-            .borders(BorderSides::ALL)
-            .border_style(borders_style)
-            .border_type(borders.modifiers)
-            .style(style);
-        let title = self.props.get(Attribute::Title).map(|x| x.unwrap_title());
-        let block = match title {
-            Some((text, alignment)) => block.title(text).title_alignment(alignment),
-            None => block,
-        };
+        let title = self
+            .props
+            .get_ref(Attribute::Title)
+            .and_then(|x| x.as_title());
+        let block = crate::utils::get_block(borders, title, focus, inactive_style);
+
         let selected_text: String = match self.states.choices.get(self.states.selected) {
             None => String::default(),
             Some(s) => s.clone(),
         };
-        let p: Paragraph = Paragraph::new(selected_text).style(style).block(block);
+        let p: Paragraph = Paragraph::new(selected_text)
+            .style(normal_style)
+            .block(block);
         render.render_widget(p, area);
     }
 

--- a/src/components/table.rs
+++ b/src/components/table.rs
@@ -319,6 +319,12 @@ impl MockComponent for Table {
                     AttrValue::TextModifiers(TextModifiers::empty()),
                 )
                 .unwrap_text_modifiers();
+
+            let normal_style = Style::default()
+                .fg(foreground)
+                .bg(background)
+                .add_modifier(modifiers);
+
             let title = crate::utils::get_title_or_center(&self.props);
             let borders = self
                 .props
@@ -344,12 +350,15 @@ impl MockComponent for Table {
                 .map(|x| x.unwrap_color());
             let widths: Vec<Constraint> = self.layout();
 
-            let mut table = TuiTable::new(rows, &widths).block(crate::utils::get_block(
-                borders,
-                Some(&title),
-                focus,
-                inactive_style,
-            ));
+            let mut table =
+                TuiTable::new(rows, &widths)
+                    .style(normal_style)
+                    .block(crate::utils::get_block(
+                        borders,
+                        Some(&title),
+                        focus,
+                        inactive_style,
+                    ));
             if let Some(highlighted_color) = highlighted_color {
                 table =
                     table.row_highlight_style(Style::default().fg(highlighted_color).add_modifier(
@@ -389,16 +398,7 @@ impl MockComponent for Table {
                 })
                 .unwrap_or_default();
             if !headers.is_empty() {
-                table = table.header(
-                    Row::new(headers)
-                        .style(
-                            Style::default()
-                                .fg(foreground)
-                                .bg(background)
-                                .add_modifier(modifiers),
-                        )
-                        .height(row_height),
-                );
+                table = table.header(Row::new(headers).style(normal_style).height(row_height));
             }
             if self.is_scrollable() {
                 let mut state: TableState = TableState::default();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -118,17 +118,20 @@ pub fn get_block<T: AsRef<str>>(
     focus: bool,
     inactive_style: Option<Style>,
 ) -> Block {
-    let title = title.map_or(("", Alignment::Left), |v| (v.0.as_ref(), v.1));
-    Block::default()
+    let mut block = Block::default()
         .borders(props.sides)
         .border_style(if focus {
             props.style()
         } else {
             inactive_style.unwrap_or_else(|| Style::default().fg(Color::Reset).bg(Color::Reset))
         })
-        .border_type(props.modifiers)
-        .title(title.0)
-        .title_alignment(title.1)
+        .border_type(props.modifiers);
+
+    if let Some((title, alignment)) = title {
+        block = block.title(title.as_ref()).title_alignment(*alignment);
+    }
+
+    block
 }
 
 /// Get the [`Attribute::Title`] or a Centered default


### PR DESCRIPTION
# ISSUE _NUMBER_ - PULL_REQUEST_TITLE

Re #43
This does not entirely fix #43 as it also proposes to fallback `inactive` styles to normal styling if unset (instead of reset).
Also even with this PR there are some components which dont have a `inactive` style, but still support borders, but always set `None` for `utils::get_block`, which results in using `bg: Color::Reset`.

## Description

This PR fixes a bunch of styling inconsistencies, which includes (but may not be limited to):
- Pass style correctly to the ratatui widgets (ex, `Table`, `LineGauge`, `ProgressBar`)
- Apply colors consistently (ex `Radio`, `CheckBox`, `Select`)
- Dont always overwrite border style (ex `Canvas`)

Other changes include:
- Change `utils::get_block` to *not* apply a title to the block if there is no title (This could be seen as a breaking change, at least a minor version is recommended)
- Refactor `Select` to use common functionality, instead of creating own blocks (though could likely be further refactored to minimize duplication)
- Due to not always overwriting the `Canvas` border style, `foreground` has become useless, so a note has been added (instead of straight-up removal, which definitely would be a breaking change)
- Change the `Table` example to include some extra dead space to showcase how that would look
- Change the `Table` example to set the background to showcase changes in this PR

## Type of change

Please select relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no new *C-bindings*
- [x] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit
