### PR TITLE
 Apply changes for core `Title` changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ rust-version = "1.85.1"
 
 [dependencies]
 textwrap = "^0.16"
-tuirealm = { version = "3", default-features = false, features = ["derive"], git = "https://github.com/veeso/tui-realm.git", rev = "dcf35afe5917a15e54e1a72191b5e1689649b6e7" }
+tuirealm = { version = "3", default-features = false, features = ["derive"], git = "https://github.com/veeso/tui-realm.git", rev = "17ad10bd602d00cbe5e01b35db7dec6776509bb9" }
 unicode-width = "^0.2"
 
 [dev-dependencies]

--- a/examples/bar_chart.rs
+++ b/examples/bar_chart.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use tui_realm_stdlib::BarChart;
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
-use tuirealm::props::{Alignment, BorderType, Borders, Color, Style};
+use tuirealm::props::{Alignment, BorderType, Borders, Color, Style, Title};
 use tuirealm::terminal::{CrosstermTerminalAdapter, TerminalBridge};
 use tuirealm::{
     Application, Component, Event, EventListenerCfg, MockComponent, NoUserEvent, Update,
@@ -139,7 +139,7 @@ impl Default for ChartAlfa {
         Self {
             component: BarChart::default()
                 .disabled(false)
-                .title("my incomes", Alignment::Center)
+                .title(Title::from("my incomes").alignment(Alignment::Center))
                 .label_style(Style::default().fg(Color::Yellow))
                 .bar_style(Style::default().fg(Color::LightYellow))
                 .bar_gap(6)
@@ -200,7 +200,7 @@ impl Default for ChartBeta {
         Self {
             component: BarChart::default()
                 .disabled(false)
-                .title("my incomes", Alignment::Left)
+                .title(Title::from("my incomes").alignment(Alignment::Left))
                 .label_style(Style::default().fg(Color::Yellow))
                 .bar_style(Style::default().fg(Color::LightYellow))
                 .bar_gap(6)

--- a/examples/canvas.rs
+++ b/examples/canvas.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use tui_realm_stdlib::Canvas;
-use tuirealm::props::{Alignment, Borders, Color, Shape};
+use tuirealm::props::{Alignment, Borders, Color, Shape, Title};
 use tuirealm::terminal::{CrosstermTerminalAdapter, TerminalBridge};
 use tuirealm::{
     Application, Component, Event, EventListenerCfg, MockComponent, NoUserEvent, Update,
@@ -119,7 +119,7 @@ impl Default for MyCanvas {
             component: Canvas::default()
                 .background(Color::Reset)
                 .foreground(Color::LightYellow)
-                .title("playing risiko", Alignment::Center)
+                .title(Title::from("playing risiko").alignment(Alignment::Center))
                 .borders(Borders::default().color(Color::LightBlue))
                 .marker(Marker::Dot)
                 .x_bounds((-180.0, 180.0))

--- a/examples/chart.rs
+++ b/examples/chart.rs
@@ -15,7 +15,7 @@ use tuirealm::ratatui::widgets::GraphType;
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
 use tuirealm::listener::{ListenerResult, Poll};
 use tuirealm::props::{
-    Alignment, AttrValue, Attribute, BorderType, Borders, Color, PropPayload, Style,
+    Alignment, AttrValue, Attribute, BorderType, Borders, Color, PropPayload, Style, Title,
 };
 use tuirealm::terminal::{CrosstermTerminalAdapter, TerminalBridge};
 use tuirealm::{
@@ -152,7 +152,7 @@ impl Default for ChartAlfa {
         Self {
             component: Chart::default()
                 .disabled(false)
-                .title("Temperatures in room", Alignment::Center)
+                .title(Title::from("Temperatures in room").alignment(Alignment::Center))
                 .borders(
                     Borders::default()
                         .modifiers(BorderType::Double)

--- a/examples/checkbox.rs
+++ b/examples/checkbox.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 
 use tui_realm_stdlib::Checkbox;
 use tuirealm::command::{Cmd, CmdResult, Direction};
-use tuirealm::props::{Alignment, BorderType, Borders, Color};
+use tuirealm::props::{Alignment, BorderType, Borders, Color, Title};
 use tuirealm::terminal::{CrosstermTerminalAdapter, TerminalBridge};
 use tuirealm::{
     Application, Component, Event, EventListenerCfg, MockComponent, NoUserEvent, Update,
@@ -150,7 +150,9 @@ impl Default for CheckboxAlfa {
                 )
                 .foreground(Color::LightGreen)
                 .background(Color::Black)
-                .title("Select your ice cream flavours 🍦", Alignment::Center)
+                .title(
+                    Title::from("Select your ice cream flavours 🍦").alignment(Alignment::Center),
+                )
                 .rewind(true)
                 .choices([
                     "vanilla",
@@ -206,7 +208,7 @@ impl Default for CheckboxBeta {
                 )
                 .foreground(Color::LightYellow)
                 .background(Color::Black)
-                .title("Select your toppings 🧁", Alignment::Center)
+                .title(Title::from("Select your toppings 🧁").alignment(Alignment::Center))
                 .rewind(false)
                 .choices([
                     "hazelnuts",

--- a/examples/container.rs
+++ b/examples/container.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 
 use tui_realm_stdlib::{Container, Table};
 use tuirealm::command::CmdResult;
-use tuirealm::props::{Alignment, BorderType, Borders, Color, Layout, TableBuilder};
+use tuirealm::props::{Alignment, BorderType, Borders, Color, Layout, TableBuilder, Title};
 use tuirealm::ratatui::text::Line;
 use tuirealm::terminal::{CrosstermTerminalAdapter, TerminalBridge};
 use tuirealm::{
@@ -123,7 +123,7 @@ impl Default for MyContainer {
             component: Container::default()
                 .background(Color::Yellow)
                 .foreground(Color::Yellow)
-                .title("This is a div with two tables", Alignment::Left)
+                .title(Title::from("This is a div with two tables").alignment(Alignment::Left))
                 .layout(
                     Layout::default()
                         .constraints(&[Constraint::Percentage(30), Constraint::Percentage(70)])
@@ -140,7 +140,7 @@ impl Default for MyContainer {
                             )
                             .foreground(Color::Yellow)
                             .background(Color::Black)
-                            .title("Keybindings", Alignment::Center)
+                            .title(Title::from("Keybindings").alignment(Alignment::Center))
                             .scroll(true)
                             .highlighted_color(Color::LightYellow)
                             .highlighted_str("🚀")
@@ -191,7 +191,10 @@ impl Default for MyContainer {
                             )
                             .foreground(Color::Green)
                             .background(Color::Black)
-                            .title("Keybindings (not scrollable)", Alignment::Center)
+                            .title(
+                                Title::from("Keybindings (not scrollable)")
+                                    .alignment(Alignment::Center),
+                            )
                             .scroll(false)
                             .highlighted_color(Color::Green)
                             .highlighted_str(">> ")

--- a/examples/input.rs
+++ b/examples/input.rs
@@ -8,7 +8,7 @@ use tui_realm_stdlib::Input;
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
 use tuirealm::event::KeyModifiers;
 use tuirealm::props::{
-    Alignment, AttrValue, Attribute, BorderType, Borders, Color, InputType, Style,
+    Alignment, AttrValue, Attribute, BorderType, Borders, Color, InputType, Style, Title,
 };
 use tuirealm::terminal::{CrosstermTerminalAdapter, TerminalBridge};
 use tuirealm::{
@@ -204,7 +204,7 @@ impl Default for InputText {
                 )
                 .foreground(Color::LightYellow)
                 .input_type(InputType::Text)
-                .title("Username", Alignment::Left)
+                .title(Title::from("Username").alignment(Alignment::Left))
                 .value("veeso")
                 .invalid_style(Style::default().fg(Color::Red)),
         }
@@ -261,7 +261,7 @@ impl Default for InputEmail {
                 )
                 .foreground(Color::LightCyan)
                 .input_type(InputType::Email)
-                .title("Email", Alignment::Left)
+                .title(Title::from("Email").alignment(Alignment::Left))
                 .placeholder(
                     "test@example.com",
                     Style::default().fg(Color::Rgb(120, 120, 120)),
@@ -322,7 +322,7 @@ impl Default for InputNumber {
                 .foreground(Color::LightGreen)
                 .input_type(InputType::UnsignedInteger)
                 .input_len(2)
-                .title("What's your age", Alignment::Left)
+                .title(Title::from("What's your age").alignment(Alignment::Left))
                 .invalid_style(Style::default().fg(Color::Red)),
         }
     }
@@ -378,7 +378,7 @@ impl Default for InputPassword {
                 )
                 .foreground(Color::LightMagenta)
                 .input_type(InputType::Password('●'))
-                .title("Password", Alignment::Left)
+                .title(Title::from("Password").alignment(Alignment::Left))
                 .invalid_style(Style::default().fg(Color::Red)),
         }
     }
@@ -435,7 +435,7 @@ impl Default for InputPhone {
                 .foreground(Color::LightBlue)
                 .input_type(InputType::Telephone)
                 .input_len(14)
-                .title("Phone number", Alignment::Left)
+                .title(Title::from("Phone number").alignment(Alignment::Left))
                 .placeholder(
                     "+39366123123",
                     Style::default().fg(Color::Rgb(120, 120, 120)),
@@ -495,7 +495,7 @@ impl Default for InputColor {
                 )
                 .foreground(Color::White)
                 .input_type(InputType::Color)
-                .title("What's your favourite color", Alignment::Left)
+                .title(Title::from("What's your favourite color").alignment(Alignment::Left))
                 .invalid_style(Style::default().fg(Color::Red)),
         }
     }

--- a/examples/line_gauge.rs
+++ b/examples/line_gauge.rs
@@ -12,7 +12,7 @@ use tui_realm_stdlib::props::LINE_GAUGE_STYLE_THICK;
 use tuirealm::command::CmdResult;
 use tuirealm::listener::{ListenerResult, Poll};
 use tuirealm::props::{
-    Alignment, AttrValue, Attribute, BorderType, Borders, Color, PropPayload, PropValue,
+    Alignment, AttrValue, Attribute, BorderType, Borders, Color, PropPayload, PropValue, Title,
 };
 use tuirealm::terminal::{CrosstermTerminalAdapter, TerminalBridge};
 use tuirealm::{
@@ -175,7 +175,7 @@ impl Default for GaugeAlfa {
                 )
                 .foreground(Color::Green)
                 .label("0%")
-                .title("Loading...", Alignment::Center)
+                .title(Title::from("Loading...").alignment(Alignment::Center))
                 .style(LINE_GAUGE_STYLE_THICK)
                 .progress(0.0),
         }
@@ -219,7 +219,7 @@ impl Default for GaugeBeta {
                 )
                 .foreground(Color::Blue)
                 .label("0%")
-                .title("Loading...", Alignment::Center)
+                .title(Title::from("Loading...").alignment(Alignment::Center))
                 .progress(0.0),
         }
     }

--- a/examples/list.rs
+++ b/examples/list.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 
 use tui_realm_stdlib::List;
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
-use tuirealm::props::{Alignment, BorderType, Borders, Color};
+use tuirealm::props::{Alignment, BorderType, Borders, Color, Title};
 use tuirealm::ratatui::style::Stylize;
 use tuirealm::ratatui::text::Span;
 use tuirealm::terminal::{CrosstermTerminalAdapter, TerminalBridge};
@@ -150,7 +150,7 @@ impl Default for ListAlfa {
                         .modifiers(BorderType::Rounded)
                         .color(Color::Yellow),
                 )
-                .title("Lorem ipsum (scrollable)", Alignment::Center)
+                .title(Title::from("Lorem ipsum (scrollable)").alignment(Alignment::Center))
                 .scroll(true)
                 .highlighted_color(Color::LightYellow)
                 .highlighted_str("🚀")
@@ -273,7 +273,7 @@ impl Default for ListBeta {
                         .color(Color::Green),
                 )
                 .foreground(Color::Green)
-                .title("Lorem ipsum (unscrollable)", Alignment::Center)
+                .title(Title::from("Lorem ipsum (unscrollable)").alignment(Alignment::Center))
                 .scroll(false)
                 .rows([
                     vec![

--- a/examples/paragraph.rs
+++ b/examples/paragraph.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 
 use tui_realm_stdlib::Paragraph;
 use tuirealm::command::CmdResult;
-use tuirealm::props::{Alignment, BorderType, Borders, Color};
+use tuirealm::props::{Alignment, BorderType, Borders, Color, Title};
 use tuirealm::ratatui::style::Stylize;
 use tuirealm::ratatui::text::Line;
 use tuirealm::terminal::{CrosstermTerminalAdapter, TerminalBridge};
@@ -150,7 +150,7 @@ impl Default for ParagraphAlfa {
                 )
                 .foreground(Color::Yellow)
                 .background(Color::Black)
-                .title("Lorem ipsum (wrap)", Alignment::Center)
+                .title(Title::from("Lorem ipsum (wrap)").alignment(Alignment::Center))
                 .wrap(true)
                 .text(vec![
                     Line::raw("Lorem ipsum dolor sit amet,").underlined().fg(Color::Green),
@@ -187,7 +187,7 @@ impl Default for ParagraphBeta {
                 )
                 .foreground(Color::Cyan)
                 .background(Color::Black)
-                .title("Lorem ipsum (no wrap)", Alignment::Center)
+                .title(Title::from("Lorem ipsum (no wrap)").alignment(Alignment::Center))
                 .wrap(false)
                 .text(vec![
                     Line::raw("Lorem ipsum dolor sit amet,").underlined().fg(Color::Green),

--- a/examples/progress_bar.rs
+++ b/examples/progress_bar.rs
@@ -11,7 +11,7 @@ use tui_realm_stdlib::{Label, ProgressBar};
 use tuirealm::command::CmdResult;
 use tuirealm::listener::{ListenerResult, Poll};
 use tuirealm::props::{
-    Alignment, AttrValue, Attribute, BorderType, Borders, Color, PropPayload, PropValue,
+    Alignment, AttrValue, Attribute, BorderType, Borders, Color, PropPayload, PropValue, Title,
 };
 use tuirealm::terminal::{CrosstermTerminalAdapter, TerminalBridge};
 use tuirealm::{
@@ -203,7 +203,7 @@ impl Default for GaugeAlfa {
                 )
                 .foreground(Color::Green)
                 .label("0%")
-                .title("Fast Loading...", Alignment::Center)
+                .title(Title::from("Fast Loading...").alignment(Alignment::Center))
                 .progress(0.0),
         }
     }
@@ -246,7 +246,7 @@ impl Default for GaugeBeta {
                 )
                 .foreground(Color::Yellow)
                 .label("0%")
-                .title("Slow Loading...", Alignment::Center)
+                .title(Title::from("Slow Loading...").alignment(Alignment::Center))
                 .progress(0.0),
         }
     }

--- a/examples/radio.rs
+++ b/examples/radio.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 
 use tui_realm_stdlib::Radio;
 use tuirealm::command::{Cmd, CmdResult, Direction};
-use tuirealm::props::{Alignment, BorderType, Borders, Color};
+use tuirealm::props::{Alignment, BorderType, Borders, Color, Title};
 use tuirealm::terminal::{CrosstermTerminalAdapter, TerminalBridge};
 use tuirealm::{
     Application, Component, Event, EventListenerCfg, MockComponent, NoUserEvent, Update,
@@ -149,7 +149,7 @@ impl Default for RadioAlfa {
                         .color(Color::LightGreen),
                 )
                 .foreground(Color::LightGreen)
-                .title("Select your ice cream flavour 🍦", Alignment::Center)
+                .title(Title::from("Select your ice cream flavour 🍦").alignment(Alignment::Center))
                 .rewind(true)
                 .choices([
                     "vanilla",
@@ -200,7 +200,7 @@ impl Default for RadioBeta {
                         .color(Color::LightYellow),
                 )
                 .foreground(Color::LightYellow)
-                .title("Select your topping 🧁", Alignment::Center)
+                .title(Title::from("Select your topping 🧁").alignment(Alignment::Center))
                 .rewind(false)
                 .choices([
                     "hazelnuts",

--- a/examples/select.rs
+++ b/examples/select.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 use tui_realm_stdlib::Select;
 use tuirealm::State;
 use tuirealm::command::{Cmd, CmdResult, Direction};
-use tuirealm::props::{Alignment, BorderType, Borders, Color};
+use tuirealm::props::{Alignment, BorderType, Borders, Color, Title};
 use tuirealm::terminal::{CrosstermTerminalAdapter, TerminalBridge};
 use tuirealm::{
     Application, Component, Event, EventListenerCfg, MockComponent, NoUserEvent, Update,
@@ -160,7 +160,7 @@ impl Default for SelectAlfa {
                         .color(Color::LightGreen),
                 )
                 .foreground(Color::LightGreen)
-                .title("Select your ice cream flavour 🍦", Alignment::Center)
+                .title(Title::from("Select your ice cream flavour 🍦").alignment(Alignment::Center))
                 .rewind(true)
                 .highlighted_color(Color::LightGreen)
                 .highlighted_str(">> ")
@@ -217,7 +217,7 @@ impl Default for SelectBeta {
                         .color(Color::LightYellow),
                 )
                 .foreground(Color::LightYellow)
-                .title("Select your topping 🧁", Alignment::Center)
+                .title(Title::from("Select your topping 🧁").alignment(Alignment::Center))
                 .rewind(false)
                 .highlighted_color(Color::LightYellow)
                 .highlighted_str(">> ")

--- a/examples/sparkline.rs
+++ b/examples/sparkline.rs
@@ -13,7 +13,7 @@ use tuirealm::ratatui::layout::{Constraint, Direction as LayoutDirection, Layout
 use tuirealm::command::CmdResult;
 use tuirealm::listener::{ListenerResult, Poll};
 use tuirealm::props::{
-    Alignment, AttrValue, Attribute, BorderType, Borders, Color, PropPayload, PropValue,
+    Alignment, AttrValue, Attribute, BorderType, Borders, Color, PropPayload, PropValue, Title,
 };
 use tuirealm::terminal::{CrosstermTerminalAdapter, TerminalBridge};
 use tuirealm::{
@@ -150,7 +150,7 @@ impl Default for SparklineAlfa {
     fn default() -> Self {
         Self {
             component: Sparkline::default()
-                .title("bandwidth (Mbps) *data is fake*", Alignment::Center)
+                .title(Title::from("bandwidth (Mbps) *data is fake*").alignment(Alignment::Center))
                 .borders(
                     Borders::default()
                         .modifiers(BorderType::Double)

--- a/examples/table.rs
+++ b/examples/table.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 
 use tui_realm_stdlib::Table;
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
-use tuirealm::props::{Alignment, BorderType, Borders, Color, TableBuilder};
+use tuirealm::props::{Alignment, BorderType, Borders, Color, TableBuilder, Title};
 use tuirealm::ratatui::text::Line;
 use tuirealm::terminal::{CrosstermTerminalAdapter, TerminalBridge};
 use tuirealm::{
@@ -151,7 +151,7 @@ impl Default for TableAlfa {
                 )
                 .foreground(Color::Yellow)
                 .background(Color::Black)
-                .title("Keybindings", Alignment::Center)
+                .title(Title::from("Keybindings").alignment(Alignment::Center))
                 .scroll(true)
                 .highlighted_color(Color::LightYellow)
                 .highlighted_str("🚀")
@@ -242,7 +242,7 @@ impl Default for TableBeta {
                 )
                 .foreground(Color::Green)
                 .background(Color::Gray)
-                .title("Keybindings (not scrollable)", Alignment::Center)
+                .title(Title::from("Keybindings (not scrollable)").alignment(Alignment::Center))
                 .scroll(false)
                 .highlighted_color(Color::Green)
                 .highlighted_str(">> ")

--- a/examples/textarea.rs
+++ b/examples/textarea.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 
 use tui_realm_stdlib::Textarea;
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
-use tuirealm::props::{Alignment, BorderType, Borders, Color};
+use tuirealm::props::{Alignment, BorderType, Borders, Color, Title};
 use tuirealm::ratatui::style::Stylize;
 use tuirealm::ratatui::text::Span;
 use tuirealm::terminal::{CrosstermTerminalAdapter, TerminalBridge};
@@ -151,7 +151,7 @@ impl Default for TextareaAlfa {
                         .color(Color::Yellow),
                 )
                 .foreground(Color::Yellow)
-                .title("Night Moves (Bob Seger)", Alignment::Center)
+                .title(Title::from("Night Moves (Bob Seger)").alignment(Alignment::Center))
                 .step(4)
                 .highlighted_str("🎵")
                 .text_rows([
@@ -220,7 +220,7 @@ impl Default for TextareaBeta {
                         .color(Color::LightBlue),
                 )
                 .foreground(Color::LightBlue)
-                .title("Roxanne (The Police)", Alignment::Center)
+                .title(Title::from("Roxanne (The Police)").alignment(Alignment::Center))
                 .step(4)
                 .highlighted_str("🎵")
                 .text_rows([

--- a/src/components/bar_chart.rs
+++ b/src/components/bar_chart.rs
@@ -5,7 +5,7 @@
 use std::collections::LinkedList;
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
 use tuirealm::props::{
-    Alignment, AttrValue, Attribute, Borders, Color, PropPayload, PropValue, Props, Style,
+    AttrValue, Attribute, Borders, Color, PropPayload, PropValue, Props, Style, Title,
 };
 use tuirealm::ratatui::{layout::Rect, widgets::BarChart as TuiBarChart};
 use tuirealm::{Frame, MockComponent, State};
@@ -103,8 +103,8 @@ impl BarChart {
         self
     }
 
-    pub fn title<S: Into<String>>(mut self, t: S, a: Alignment) -> Self {
-        self.attr(Attribute::Title, AttrValue::Title((t.into(), a)));
+    pub fn title<T: Into<Title>>(mut self, title: T) -> Self {
+        self.attr(Attribute::Title, AttrValue::Title(title.into()));
         self
     }
 
@@ -335,6 +335,7 @@ mod test {
     use super::*;
 
     use pretty_assertions::assert_eq;
+    use tuirealm::props::Alignment;
 
     #[test]
     fn test_components_bar_chart_states() {
@@ -363,7 +364,7 @@ mod test {
     fn test_components_bar_chart() {
         let mut component: BarChart = BarChart::default()
             .disabled(false)
-            .title("my incomes", Alignment::Center)
+            .title(Title::from("my incomes").alignment(Alignment::Center))
             .label_style(Style::default().fg(Color::Yellow))
             .bar_style(Style::default().fg(Color::LightYellow))
             .bar_gap(2)

--- a/src/components/canvas.rs
+++ b/src/components/canvas.rs
@@ -4,7 +4,7 @@
 
 use tuirealm::command::{Cmd, CmdResult};
 use tuirealm::props::{
-    Alignment, AttrValue, Attribute, Borders, Color, PropPayload, PropValue, Props, Shape, Style,
+    AttrValue, Attribute, Borders, Color, PropPayload, PropValue, Props, Shape, Style, Title,
 };
 use tuirealm::ratatui::symbols::Marker;
 use tuirealm::ratatui::text::Line as Spans;
@@ -52,8 +52,8 @@ impl Canvas {
         self
     }
 
-    pub fn title<S: Into<String>>(mut self, t: S, a: Alignment) -> Self {
-        self.attr(Attribute::Title, AttrValue::Title((t.into(), a)));
+    pub fn title<T: Into<Title>>(mut self, title: T) -> Self {
+        self.attr(Attribute::Title, AttrValue::Title(title.into()));
         self
     }
 
@@ -238,13 +238,16 @@ mod test {
     use super::*;
 
     use pretty_assertions::assert_eq;
-    use tuirealm::ratatui::widgets::canvas::{Line, Map, MapResolution, Rectangle};
+    use tuirealm::{
+        props::Alignment,
+        ratatui::widgets::canvas::{Line, Map, MapResolution, Rectangle},
+    };
 
     #[test]
     fn test_component_canvas_with_shapes() {
         let component: Canvas = Canvas::default()
             .background(Color::Black)
-            .title("playing risiko", Alignment::Center)
+            .title(Title::from("playing risiko").alignment(Alignment::Center))
             .borders(Borders::default())
             .marker(Marker::Dot)
             .x_bounds((-180.0, 180.0))

--- a/src/components/chart/chart.rs
+++ b/src/components/chart/chart.rs
@@ -6,7 +6,7 @@ use std::any::Any;
 
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
 use tuirealm::props::{
-    Alignment, AttrValue, Attribute, Borders, Color, PropPayload, PropValue, Props, Style,
+    AttrValue, Attribute, Borders, Color, PropPayload, PropValue, Props, Style, Title,
 };
 use tuirealm::ratatui::text::Line;
 use tuirealm::ratatui::{
@@ -108,10 +108,8 @@ impl Chart {
         self
     }
 
-    /// Set a title for the Block
-    pub fn title<S: Into<String>>(mut self, t: S, a: Alignment) -> Self {
-        self.props
-            .set(Attribute::Title, AttrValue::Title((t.into(), a)));
+    pub fn title<T: Into<Title>>(mut self, title: T) -> Self {
+        self.attr(Attribute::Title, AttrValue::Title(title.into()));
         self
     }
 
@@ -422,7 +420,10 @@ mod test {
     use super::*;
 
     use pretty_assertions::assert_eq;
-    use tuirealm::ratatui::{symbols::Marker, widgets::GraphType};
+    use tuirealm::{
+        props::Alignment,
+        ratatui::{symbols::Marker, widgets::GraphType},
+    };
 
     #[test]
     fn test_components_chart_states() {
@@ -454,7 +455,7 @@ mod test {
             .background(Color::Reset)
             .foreground(Color::Reset)
             .borders(Borders::default())
-            .title("average temperatures in Udine", Alignment::Center)
+            .title(Title::from("average temperatures in Udine").alignment(Alignment::Center))
             .x_bounds((0.0, 11.0))
             .x_labels(&[
                 "january",

--- a/src/components/checkbox.rs
+++ b/src/components/checkbox.rs
@@ -27,8 +27,8 @@
  */
 use tuirealm::command::{Cmd, CmdResult, Direction};
 use tuirealm::props::{
-    Alignment, AttrValue, Attribute, Borders, Color, PropPayload, PropValue, Props, Style,
-    TextModifiers,
+    AttrValue, Attribute, Borders, Color, PropPayload, PropValue, Props, Style, TextModifiers,
+    Title,
 };
 use tuirealm::ratatui::text::Line as Spans;
 use tuirealm::ratatui::{layout::Rect, text::Span, widgets::Tabs};
@@ -143,8 +143,8 @@ impl Checkbox {
         self
     }
 
-    pub fn title<S: Into<String>>(mut self, t: S, a: Alignment) -> Self {
-        self.attr(Attribute::Title, AttrValue::Title((t.into(), a)));
+    pub fn title<T: Into<Title>>(mut self, title: T) -> Self {
+        self.attr(Attribute::Title, AttrValue::Title(title.into()));
         self
     }
 
@@ -326,7 +326,7 @@ mod test {
     use super::*;
 
     use pretty_assertions::{assert_eq, assert_ne};
-    use tuirealm::props::{PropPayload, PropValue};
+    use tuirealm::props::{Alignment, PropPayload, PropValue};
 
     #[test]
     fn test_components_checkbox_states() {
@@ -404,7 +404,7 @@ mod test {
             .background(Color::Blue)
             .foreground(Color::Red)
             .borders(Borders::default())
-            .title("Which food do you prefer?", Alignment::Center)
+            .title(Title::from("Which food do you prefer?").alignment(Alignment::Center))
             .choices(["Pizza", "Hummus", "Ramen", "Gyoza", "Pasta"])
             .values(&[1, 4])
             .rewind(false);

--- a/src/components/container.rs
+++ b/src/components/container.rs
@@ -7,7 +7,7 @@
 //! By default it will forward `Commands' to all the children and will return a `CmdResult::Batch` with all the results.
 
 use tuirealm::command::{Cmd, CmdResult};
-use tuirealm::props::{Alignment, AttrValue, Attribute, Borders, Color, Layout, Props};
+use tuirealm::props::{AttrValue, Attribute, Borders, Color, Layout, Props, Title};
 use tuirealm::ratatui::layout::Rect;
 use tuirealm::{Frame, MockComponent, State};
 
@@ -40,8 +40,8 @@ impl Container {
         self
     }
 
-    pub fn title<S: Into<String>>(mut self, t: S, a: Alignment) -> Self {
-        self.attr(Attribute::Title, AttrValue::Title((t.into(), a)));
+    pub fn title<T: Into<Title>>(mut self, title: T) -> Self {
+        self.attr(Attribute::Title, AttrValue::Title(title.into()));
         self
     }
 
@@ -114,13 +114,14 @@ mod tests {
     use super::*;
 
     use pretty_assertions::assert_eq;
+    use tuirealm::props::Alignment;
 
     #[test]
     fn test_components_paragraph() {
         let component = Container::default()
             .background(Color::Blue)
             .foreground(Color::Red)
-            .title("title", Alignment::Center);
+            .title(Title::from("title").alignment(Alignment::Center));
         // Get value
         assert_eq!(component.state(), State::None);
     }

--- a/src/components/input.rs
+++ b/src/components/input.rs
@@ -7,7 +7,7 @@ use super::props::{INPUT_INVALID_STYLE, INPUT_PLACEHOLDER, INPUT_PLACEHOLDER_STY
 use crate::utils::calc_utf8_cursor_position;
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
 use tuirealm::props::{
-    Alignment, AttrValue, Attribute, Borders, Color, InputType, Props, Style, TextModifiers,
+    AttrValue, Attribute, Borders, Color, InputType, Props, Style, TextModifiers, Title,
 };
 use tuirealm::ratatui::{layout::Rect, widgets::Paragraph};
 use tuirealm::{Frame, MockComponent, State, StateValue};
@@ -227,8 +227,8 @@ impl Input {
         self
     }
 
-    pub fn title<S: Into<String>>(mut self, t: S, a: Alignment) -> Self {
-        self.attr(Attribute::Title, AttrValue::Title((t.into(), a)));
+    pub fn title<T: Into<Title>>(mut self, title: T) -> Self {
+        self.attr(Attribute::Title, AttrValue::Title(title.into()));
         self
     }
 
@@ -501,6 +501,7 @@ mod tests {
     use super::*;
 
     use pretty_assertions::assert_eq;
+    use tuirealm::props::Alignment;
 
     #[test]
     fn test_components_input_states() {
@@ -551,7 +552,7 @@ mod tests {
             .inactive(Style::default())
             .input_len(5)
             .input_type(InputType::Text)
-            .title("pippo", Alignment::Center)
+            .title(Title::from("pippo").alignment(Alignment::Center))
             .value("home");
         // Verify initial state
         assert_eq!(component.states.cursor, 4);

--- a/src/components/input.rs
+++ b/src/components/input.rs
@@ -303,7 +303,10 @@ impl MockComponent for Input {
                     AttrValue::TextModifiers(TextModifiers::empty()),
                 )
                 .unwrap_text_modifiers();
-            let title = crate::utils::get_title_or_center(&self.props);
+            let title = self
+                .props
+                .get_ref(Attribute::Title)
+                .and_then(|v| v.as_title());
             let borders = self
                 .props
                 .get_or(Attribute::Borders, AttrValue::Borders(Borders::default()))
@@ -317,7 +320,7 @@ impl MockComponent for Input {
                 .get(Attribute::FocusStyle)
                 .map(|x| x.unwrap_style());
             let itype = self.get_input_type();
-            let mut block = crate::utils::get_block(borders, Some(&title), focus, inactive_style);
+            let mut block = crate::utils::get_block(borders, title, focus, inactive_style);
             // Apply invalid style
             if focus && !self.is_valid() {
                 if let Some(style) = self
@@ -330,7 +333,7 @@ impl MockComponent for Input {
                         .get_or(Attribute::Borders, AttrValue::Borders(Borders::default()))
                         .unwrap_borders()
                         .color(style.fg.unwrap_or(Color::Reset));
-                    block = crate::utils::get_block(borders, Some(&title), focus, None);
+                    block = crate::utils::get_block(borders, title, focus, None);
                     foreground = style.fg.unwrap_or(Color::Reset);
                     background = style.bg.unwrap_or(Color::Reset);
                 }

--- a/src/components/line_gauge.rs
+++ b/src/components/line_gauge.rs
@@ -9,8 +9,8 @@ use super::props::{
 
 use tuirealm::command::{Cmd, CmdResult};
 use tuirealm::props::{
-    Alignment, AttrValue, Attribute, Borders, Color, PropPayload, PropValue, Props, Style,
-    TextModifiers,
+    AttrValue, Attribute, Borders, Color, PropPayload, PropValue, Props, Style, TextModifiers,
+    Title,
 };
 use tuirealm::ratatui::{
     layout::Rect,
@@ -51,8 +51,8 @@ impl LineGauge {
         self
     }
 
-    pub fn title<S: Into<String>>(mut self, t: S, a: Alignment) -> Self {
-        self.attr(Attribute::Title, AttrValue::Title((t.into(), a)));
+    pub fn title<T: Into<Title>>(mut self, title: T) -> Self {
+        self.attr(Attribute::Title, AttrValue::Title(title.into()));
         self
     }
 
@@ -212,6 +212,7 @@ mod test {
     use super::*;
 
     use pretty_assertions::assert_eq;
+    use tuirealm::props::Alignment;
 
     #[test]
     fn test_components_progress_bar() {
@@ -219,7 +220,7 @@ mod test {
             .background(Color::Red)
             .foreground(Color::White)
             .progress(0.60)
-            .title("Downloading file...", Alignment::Center)
+            .title(Title::from("Downloading file...").alignment(Alignment::Center))
             .label("60% - ETA 00:20")
             .style(LINE_GAUGE_STYLE_DOUBLE)
             .borders(Borders::default());
@@ -234,7 +235,7 @@ mod test {
             .background(Color::Red)
             .foreground(Color::White)
             .progress(6.0)
-            .title("Downloading file...", Alignment::Center)
+            .title(Title::from("Downloading file...").alignment(Alignment::Center))
             .label("60% - ETA 00:20")
             .borders(Borders::default());
     }
@@ -246,7 +247,7 @@ mod test {
             .background(Color::Red)
             .foreground(Color::White)
             .style(254)
-            .title("Downloading file...", Alignment::Center)
+            .title(Title::from("Downloading file...").alignment(Alignment::Center))
             .label("60% - ETA 00:20")
             .borders(Borders::default());
     }

--- a/src/components/list.rs
+++ b/src/components/list.rs
@@ -4,8 +4,8 @@
 
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
 use tuirealm::props::{
-    Alignment, AttrValue, Attribute, Borders, Color, LineStatic, PropPayload, PropValue, Props,
-    Style, TextModifiers,
+    AttrValue, Attribute, Borders, Color, LineStatic, PropPayload, PropValue, Props, Style,
+    TextModifiers, Title,
 };
 use tuirealm::ratatui::{
     layout::Rect,
@@ -142,8 +142,8 @@ impl List {
         self
     }
 
-    pub fn title<S: Into<String>>(mut self, t: S, a: Alignment) -> Self {
-        self.attr(Attribute::Title, AttrValue::Title((t.into(), a)));
+    pub fn title<T: Into<Title>>(mut self, title: T) -> Self {
+        self.attr(Attribute::Title, AttrValue::Title(title.into()));
         self
     }
 
@@ -422,7 +422,10 @@ mod tests {
 
     use super::*;
     use pretty_assertions::assert_eq;
-    use tuirealm::ratatui::text::{Line, Span};
+    use tuirealm::{
+        props::Alignment,
+        ratatui::text::{Line, Span},
+    };
 
     #[test]
     fn list_states() {
@@ -469,7 +472,7 @@ mod tests {
             .scroll(true)
             .step(4)
             .borders(Borders::default())
-            .title("events", Alignment::Center)
+            .title(Title::from("events").alignment(Alignment::Center))
             .rewind(true)
             .rows([
                 // Note: this could be improved if ratatui implements "From<[X; _]> for Line"
@@ -589,7 +592,7 @@ mod tests {
             .highlighted_str("🚀")
             .modifiers(TextModifiers::BOLD)
             .borders(Borders::default())
-            .title("events", Alignment::Center)
+            .title(Title::from("events").alignment(Alignment::Center))
             .rows([
                 Line::from("KeyCode::Down OnKey Move cursor down"),
                 Line::from("KeyCode::Up OnKey Move cursor up"),
@@ -612,7 +615,7 @@ mod tests {
             .highlighted_str("🚀")
             .modifiers(TextModifiers::BOLD)
             .borders(Borders::default())
-            .title("events", Alignment::Center)
+            .title(Title::from("events").alignment(Alignment::Center))
             .rows([
                 "KeyCode::Down OnKey Move cursor down",
                 "KeyCode::Up OnKey Move cursor up",

--- a/src/components/list.rs
+++ b/src/components/list.rs
@@ -234,7 +234,10 @@ impl MockComponent for List {
                     AttrValue::TextModifiers(TextModifiers::empty()),
                 )
                 .unwrap_text_modifiers();
-            let title = crate::utils::get_title_or_center(&self.props);
+            let title = self
+                .props
+                .get_ref(Attribute::Title)
+                .and_then(|v| v.as_title());
             let borders = self
                 .props
                 .get_or(Attribute::Borders, AttrValue::Borders(Borders::default()))
@@ -248,7 +251,7 @@ impl MockComponent for List {
                 .get(Attribute::FocusStyle)
                 .map(|x| x.unwrap_style());
             let active: bool = if self.scrollable() { focus } else { true };
-            let div = crate::utils::get_block(borders, Some(&title), active, inactive_style);
+            let div = crate::utils::get_block(borders, title, active, inactive_style);
             // Make list entries
             let payload = self
                 .props

--- a/src/components/paragraph.rs
+++ b/src/components/paragraph.rs
@@ -8,7 +8,7 @@
 
 use tuirealm::command::{Cmd, CmdResult};
 use tuirealm::props::{
-    Alignment, AttrValue, Attribute, Borders, Color, Props, Style, TextModifiers, TextStatic,
+    Alignment, AttrValue, Attribute, Borders, Color, Props, Style, TextModifiers, TextStatic, Title,
 };
 use tuirealm::ratatui::{
     layout::Rect,
@@ -55,8 +55,8 @@ impl Paragraph {
         self
     }
 
-    pub fn title<S: Into<String>>(mut self, t: S, a: Alignment) -> Self {
-        self.attr(Attribute::Title, AttrValue::Title((t.into(), a)));
+    pub fn title<T: Into<Title>>(mut self, title: T) -> Self {
+        self.attr(Attribute::Title, AttrValue::Title(title.into()));
         self
     }
 
@@ -178,7 +178,7 @@ mod tests {
                 Line::from(" to quit"),
             ])
             .wrap(true)
-            .title("title", Alignment::Center);
+            .title(Title::from("title").alignment(Alignment::Center));
         // Get value
         assert_eq!(component.state(), State::None);
     }

--- a/src/components/progress_bar.rs
+++ b/src/components/progress_bar.rs
@@ -4,8 +4,8 @@
 
 use tuirealm::command::{Cmd, CmdResult};
 use tuirealm::props::{
-    Alignment, AttrValue, Attribute, Borders, Color, PropPayload, PropValue, Props, Style,
-    TextModifiers,
+    AttrValue, Attribute, Borders, Color, PropPayload, PropValue, Props, Style, TextModifiers,
+    Title,
 };
 use tuirealm::ratatui::{layout::Rect, widgets::Gauge};
 use tuirealm::{Frame, MockComponent, State};
@@ -42,8 +42,8 @@ impl ProgressBar {
         self
     }
 
-    pub fn title<S: Into<String>>(mut self, t: S, a: Alignment) -> Self {
-        self.attr(Attribute::Title, AttrValue::Title((t.into(), a)));
+    pub fn title<T: Into<Title>>(mut self, title: T) -> Self {
+        self.attr(Attribute::Title, AttrValue::Title(title.into()));
         self
     }
 
@@ -160,6 +160,7 @@ mod test {
     use super::*;
 
     use pretty_assertions::assert_eq;
+    use tuirealm::props::Alignment;
 
     #[test]
     fn test_components_progress_bar() {
@@ -167,7 +168,7 @@ mod test {
             .background(Color::Red)
             .foreground(Color::White)
             .progress(0.60)
-            .title("Downloading file...", Alignment::Center)
+            .title(Title::from("Downloading file...").alignment(Alignment::Center))
             .label("60% - ETA 00:20")
             .borders(Borders::default());
         // Get value
@@ -181,7 +182,7 @@ mod test {
             .background(Color::Red)
             .foreground(Color::White)
             .progress(6.0)
-            .title("Downloading file...", Alignment::Center)
+            .title(Title::from("Downloading file...").alignment(Alignment::Center))
             .label("60% - ETA 00:20")
             .borders(Borders::default());
     }

--- a/src/components/radio.rs
+++ b/src/components/radio.rs
@@ -27,8 +27,8 @@
  */
 use tuirealm::command::{Cmd, CmdResult, Direction};
 use tuirealm::props::{
-    Alignment, AttrValue, Attribute, Borders, Color, PropPayload, PropValue, Props, Style,
-    TextModifiers,
+    AttrValue, Attribute, Borders, Color, PropPayload, PropValue, Props, Style, TextModifiers,
+    Title,
 };
 use tuirealm::ratatui::text::Line as Spans;
 use tuirealm::ratatui::{layout::Rect, widgets::Tabs};
@@ -119,8 +119,8 @@ impl Radio {
         self
     }
 
-    pub fn title<S: Into<String>>(mut self, t: S, a: Alignment) -> Self {
-        self.attr(Attribute::Title, AttrValue::Title((t.into(), a)));
+    pub fn title<T: Into<Title>>(mut self, title: T) -> Self {
+        self.attr(Attribute::Title, AttrValue::Title(title.into()));
         self
     }
 
@@ -273,7 +273,7 @@ mod test {
     use super::*;
 
     use pretty_assertions::assert_eq;
-    use tuirealm::props::{PropPayload, PropValue};
+    use tuirealm::props::{Alignment, PropPayload, PropValue};
 
     #[test]
     fn test_components_radio_states() {
@@ -337,7 +337,7 @@ mod test {
             .background(Color::Blue)
             .foreground(Color::Red)
             .borders(Borders::default())
-            .title("C'est oui ou bien c'est non?", Alignment::Center)
+            .title(Title::from("C'est oui ou bien c'est non?").alignment(Alignment::Center))
             .choices(["Oui!", "Non", "Peut-être"])
             .value(1)
             .rewind(false);

--- a/src/components/select.rs
+++ b/src/components/select.rs
@@ -5,8 +5,8 @@
 
 use tuirealm::command::{Cmd, CmdResult, Direction};
 use tuirealm::props::{
-    Alignment, AttrValue, Attribute, BorderSides, Borders, Color, PropPayload, PropValue, Props,
-    Style, TextModifiers,
+    AttrValue, Attribute, BorderSides, Borders, Color, PropPayload, PropValue, Props, Style,
+    TextModifiers, Title,
 };
 use tuirealm::ratatui::text::Line as Spans;
 use tuirealm::ratatui::{
@@ -135,8 +135,8 @@ impl Select {
         self
     }
 
-    pub fn title<S: Into<String>>(mut self, t: S, a: Alignment) -> Self {
-        self.attr(Attribute::Title, AttrValue::Title((t.into(), a)));
+    pub fn title<T: Into<Title>>(mut self, title: T) -> Self {
+        self.attr(Attribute::Title, AttrValue::Title(title.into()));
         self
     }
 
@@ -237,7 +237,7 @@ impl Select {
             .and_then(|x| x.as_title());
         let block_a = crate::utils::get_block(borders, title, focus, inactive_style)
             .borders(BorderSides::LEFT | BorderSides::TOP | BorderSides::RIGHT);
-        let block_b = crate::utils::get_block::<&str>(borders, None, focus, inactive_style)
+        let block_b = crate::utils::get_block(borders, None, focus, inactive_style)
             .borders(BorderSides::LEFT | BorderSides::BOTTOM | BorderSides::RIGHT);
 
         let p: Paragraph = Paragraph::new(selected_text)
@@ -418,7 +418,7 @@ mod test {
 
     use pretty_assertions::assert_eq;
 
-    use tuirealm::props::{PropPayload, PropValue};
+    use tuirealm::props::{Alignment, PropPayload, PropValue};
 
     #[test]
     fn test_components_select_states() {
@@ -507,7 +507,7 @@ mod test {
             .borders(Borders::default())
             .highlighted_color(Color::Red)
             .highlighted_str(">>")
-            .title("C'est oui ou bien c'est non?", Alignment::Center)
+            .title(Title::from("C'est oui ou bien c'est non?").alignment(Alignment::Center))
             .choices(["Oui!", "Non", "Peut-être"])
             .value(1)
             .rewind(false);

--- a/src/components/sparkline.rs
+++ b/src/components/sparkline.rs
@@ -99,7 +99,10 @@ impl MockComponent for Sparkline {
                 .props
                 .get_or(Attribute::Background, AttrValue::Color(Color::Reset))
                 .unwrap_color();
-            let title = crate::utils::get_title_or_center(&self.props);
+            let title = self
+                .props
+                .get_ref(Attribute::Title)
+                .and_then(|v| v.as_title());
             let borders = self
                 .props
                 .get_or(Attribute::Borders, AttrValue::Borders(Borders::default()))
@@ -112,7 +115,7 @@ impl MockComponent for Sparkline {
             let data: Vec<u64> = self.get_data(max_entries);
             // Create widget
             let widget: TuiSparkline = TuiSparkline::default()
-                .block(crate::utils::get_block(borders, Some(&title), false, None))
+                .block(crate::utils::get_block(borders, title, false, None))
                 .data(data.as_slice())
                 .max(max_entries as u64)
                 .style(Style::default().fg(foreground).bg(background));

--- a/src/components/sparkline.rs
+++ b/src/components/sparkline.rs
@@ -4,7 +4,7 @@
 
 use tuirealm::command::{Cmd, CmdResult};
 use tuirealm::props::{
-    Alignment, AttrValue, Attribute, Borders, Color, PropPayload, PropValue, Props, Style,
+    AttrValue, Attribute, Borders, Color, PropPayload, PropValue, Props, Style, Title,
 };
 use tuirealm::ratatui::{layout::Rect, widgets::Sparkline as TuiSparkline};
 use tuirealm::{Frame, MockComponent, State};
@@ -36,8 +36,8 @@ impl Sparkline {
         self
     }
 
-    pub fn title<S: Into<String>>(mut self, t: S, a: Alignment) -> Self {
-        self.attr(Attribute::Title, AttrValue::Title((t.into(), a)));
+    pub fn title<T: Into<Title>>(mut self, title: T) -> Self {
+        self.attr(Attribute::Title, AttrValue::Title(title.into()));
         self
     }
 
@@ -147,13 +147,14 @@ mod test {
     use super::*;
 
     use pretty_assertions::assert_eq;
+    use tuirealm::props::Alignment;
 
     #[test]
     fn test_components_sparkline() {
         let component = Sparkline::default()
             .background(Color::White)
             .foreground(Color::Black)
-            .title("bandwidth", Alignment::Center)
+            .title(Title::from("bandwidth").alignment(Alignment::Center))
             .borders(Borders::default())
             .max_entries(8)
             .data(&[

--- a/src/components/table.rs
+++ b/src/components/table.rs
@@ -6,8 +6,8 @@ use std::cmp::max;
 
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
 use tuirealm::props::{
-    Alignment, AttrValue, Attribute, Borders, Color, PropPayload, PropValue, Props, Style,
-    Table as PropTable, TextModifiers,
+    AttrValue, Attribute, Borders, Color, PropPayload, PropValue, Props, Style, Table as PropTable,
+    TextModifiers, Title,
 };
 use tuirealm::ratatui::{
     layout::{Constraint, Rect},
@@ -151,8 +151,8 @@ impl Table {
         self
     }
 
-    pub fn title<S: Into<String>>(mut self, t: S, a: Alignment) -> Self {
-        self.attr(Attribute::Title, AttrValue::Title((t.into(), a)));
+    pub fn title<T: Into<Title>>(mut self, title: T) -> Self {
+        self.attr(Attribute::Title, AttrValue::Title(title.into()));
         self
     }
 
@@ -524,7 +524,7 @@ mod tests {
 
     use super::*;
     use pretty_assertions::assert_eq;
-    use tuirealm::props::TableBuilder;
+    use tuirealm::props::{Alignment, TableBuilder};
 
     #[test]
     fn table_states() {
@@ -572,7 +572,7 @@ mod tests {
             .scroll(true)
             .step(4)
             .borders(Borders::default())
-            .title("events", Alignment::Center)
+            .title(Title::from("events").alignment(Alignment::Center))
             .column_spacing(4)
             .widths(&[25, 25, 25, 25])
             .row_height(3)
@@ -705,7 +705,7 @@ mod tests {
             .highlighted_str("🚀")
             .modifiers(TextModifiers::BOLD)
             .borders(Borders::default())
-            .title("events", Alignment::Center)
+            .title(Title::from("events").alignment(Alignment::Center))
             .column_spacing(4)
             .widths(&[33, 33, 33])
             .row_height(3)
@@ -754,7 +754,7 @@ mod tests {
             .highlighted_str("🚀")
             .modifiers(TextModifiers::BOLD)
             .borders(Borders::default())
-            .title("events", Alignment::Center)
+            .title(Title::from("events").alignment(Alignment::Center))
             .table(
                 TableBuilder::default()
                     .add_col(Line::from("KeyCode::Down"))

--- a/src/components/table.rs
+++ b/src/components/table.rs
@@ -328,7 +328,10 @@ impl MockComponent for Table {
                 .bg(background)
                 .add_modifier(modifiers);
 
-            let title = crate::utils::get_title_or_center(&self.props);
+            let title = self
+                .props
+                .get_ref(Attribute::Title)
+                .and_then(|v| v.as_title());
             let borders = self
                 .props
                 .get_or(Attribute::Borders, AttrValue::Borders(Borders::default()))
@@ -358,7 +361,7 @@ impl MockComponent for Table {
                     .style(normal_style)
                     .block(crate::utils::get_block(
                         borders,
-                        Some(&title),
+                        title,
                         focus,
                         inactive_style,
                     ));

--- a/src/components/textarea.rs
+++ b/src/components/textarea.rs
@@ -8,8 +8,8 @@ extern crate unicode_width;
 
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
 use tuirealm::props::{
-    Alignment, AttrValue, Attribute, Borders, Color, PropPayload, PropValue, Props, SpanStatic,
-    Style, TextModifiers,
+    AttrValue, Attribute, Borders, Color, PropPayload, PropValue, Props, SpanStatic, Style,
+    TextModifiers, Title,
 };
 use tuirealm::ratatui::{
     layout::Rect,
@@ -145,8 +145,8 @@ impl Textarea {
         self
     }
 
-    pub fn title<S: Into<String>>(mut self, t: S, a: Alignment) -> Self {
-        self.attr(Attribute::Title, AttrValue::Title((t.into(), a)));
+    pub fn title<T: Into<Title>>(mut self, title: T) -> Self {
+        self.attr(Attribute::Title, AttrValue::Title(title.into()));
         self
     }
 
@@ -314,7 +314,7 @@ mod tests {
     use super::*;
 
     use pretty_assertions::assert_eq;
-    use tuirealm::ratatui::text::Span;
+    use tuirealm::{props::Alignment, ratatui::text::Span};
 
     #[test]
     fn test_components_textarea() {
@@ -326,7 +326,7 @@ mod tests {
             .borders(Borders::default())
             .highlighted_str("🚀")
             .step(4)
-            .title("textarea", Alignment::Center)
+            .title(Title::from("textarea").alignment(Alignment::Center))
             .text_rows([Span::from("welcome to "), Span::from("tui-realm")]);
         // Increment list index
         component.states.list_index += 1;

--- a/src/components/textarea.rs
+++ b/src/components/textarea.rs
@@ -210,7 +210,10 @@ impl MockComponent for Textarea {
                     AttrValue::TextModifiers(TextModifiers::empty()),
                 )
                 .unwrap_text_modifiers();
-            let title = crate::utils::get_title_or_center(&self.props);
+            let title = self
+                .props
+                .get_ref(Attribute::Title)
+                .and_then(|v| v.as_title());
             let borders = self
                 .props
                 .get_or(Attribute::Borders, AttrValue::Borders(Borders::default()))
@@ -230,7 +233,7 @@ impl MockComponent for Textarea {
             let mut list = List::new(lines)
                 .block(crate::utils::get_block(
                     borders,
-                    Some(&title),
+                    title,
                     focus,
                     inactive_style,
                 ))

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -8,8 +8,7 @@ extern crate unicode_width;
 use std::borrow::Cow;
 
 // local
-use tuirealm::Props;
-use tuirealm::props::{Alignment, Attribute, Borders};
+use tuirealm::props::{Alignment, Borders};
 // ext
 use tuirealm::ratatui::style::{Color, Style};
 use tuirealm::ratatui::text::{Line, Span, Text};
@@ -93,15 +92,6 @@ pub fn get_block<T: AsRef<str>>(
     }
 
     block
-}
-
-/// Get the [`Attribute::Title`] or a Centered default
-#[must_use]
-pub fn get_title_or_center(props: &Props) -> (&str, Alignment) {
-    props
-        .get_ref(Attribute::Title)
-        .and_then(|v| v.as_title())
-        .map_or(("", Alignment::Center), |v| (v.0.as_str(), v.1))
 }
 
 /// ### calc_utf8_cursor_position

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -8,11 +8,12 @@ extern crate unicode_width;
 use std::borrow::Cow;
 
 // local
-use tuirealm::props::{Alignment, Borders};
+use tuirealm::props::{Borders, Title};
 // ext
 use tuirealm::ratatui::style::{Color, Style};
 use tuirealm::ratatui::text::{Line, Span, Text};
 use tuirealm::ratatui::widgets::Block;
+use tuirealm::ratatui::widgets::block::Position;
 use unicode_width::UnicodeWidthStr;
 
 /// ### wrap_spans
@@ -72,9 +73,9 @@ pub fn wrap_spans<'a, 'b: 'a>(spans: &[&'b Span<'a>], width: usize) -> Vec<Line<
 /// Construct a block for widget using block properties.
 /// If focus is true the border color is applied, otherwise inactive_style
 #[must_use]
-pub fn get_block<T: AsRef<str>>(
+pub fn get_block(
     props: Borders,
-    title: Option<&(T, Alignment)>,
+    title: Option<&Title>,
     focus: bool,
     inactive_style: Option<Style>,
 ) -> Block<'_> {
@@ -87,8 +88,11 @@ pub fn get_block<T: AsRef<str>>(
         })
         .border_type(props.modifiers);
 
-    if let Some((title, alignment)) = title {
-        block = block.title(title.as_ref()).title_alignment(*alignment);
+    if let Some(title) = title {
+        block = match title.position {
+            Position::Top => block.title_top(borrow_clone_line(&title.content)),
+            Position::Bottom => block.title_bottom(borrow_clone_line(&title.content)),
+        };
     }
 
     block
@@ -195,8 +199,13 @@ mod test {
             .sides(BorderSides::ALL)
             .color(Color::Red)
             .modifiers(BorderType::Rounded);
-        let _ = get_block(borders, Some(&("title", Alignment::Center)), true, None);
-        let _ = get_block::<&str>(borders, None, false, None);
+        let _ = get_block(
+            borders,
+            Some(&Title::from("title").alignment(Alignment::Center)),
+            true,
+            None,
+        );
+        let _ = get_block(borders, None, false, None);
     }
 
     #[test]


### PR DESCRIPTION
# ISSUE _NUMBER_ - PULL_REQUEST_TITLE

~~Depends on #46~~
Fixes #45

## Description

This PR mainly focuses on applying all necessary changes from https://github.com/veeso/tui-realm/pull/132, in addition the following had come up:
- remove `utils::get_title_or_center` as a empty title indicates that it should not be draw at all (Note that ratatui will still draw the block border if a title there is defined, even if the title is empty and the border side is not included)

## Type of change

Please select relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no new *C-bindings*
- [x] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit

---

~~This is a DRAFT until #46 is merged first.~~