### PR TITLE
Move `Dataset` over to `Chart` and rename to `ChartDataset`

### DIFF
--- a/examples/chart.rs
+++ b/examples/chart.rs
@@ -6,7 +6,7 @@ mod utils;
 use utils::DataGen;
 
 use std::time::Duration;
-use tui_realm_stdlib::Chart;
+use tui_realm_stdlib::{Chart, ChartDataset};
 // tui
 use tuirealm::ratatui::layout::{Constraint, Direction as LayoutDirection, Layout};
 use tuirealm::ratatui::symbols::Marker;
@@ -15,7 +15,7 @@ use tuirealm::ratatui::widgets::GraphType;
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
 use tuirealm::listener::{ListenerResult, Poll};
 use tuirealm::props::{
-    Alignment, AttrValue, Attribute, BorderType, Borders, Color, Dataset, PropPayload, PropValue,
+    Alignment, AttrValue, Attribute, BorderType, Borders, Color, PropPayload,
     Style,
 };
 use tuirealm::terminal::{CrosstermTerminalAdapter, TerminalBridge};
@@ -191,7 +191,7 @@ impl Component<Msg, UserEvent> for ChartAlfa {
             Event::Keyboard(KeyEvent { code: Key::Esc, .. }) => return Some(Msg::AppClose),
             Event::User(UserEvent::DataGenerated(data)) => {
                 // Update data
-                let dataset = Dataset::default()
+                let dataset = ChartDataset::default()
                     .name("Temperatures")
                     .graph_type(GraphType::Line)
                     .marker(Marker::Braille)
@@ -199,7 +199,7 @@ impl Component<Msg, UserEvent> for ChartAlfa {
                     .data(data);
                 self.attr(
                     Attribute::Dataset,
-                    AttrValue::Payload(PropPayload::Vec(vec![PropValue::Dataset(dataset)])),
+                    AttrValue::Payload(PropPayload::Any(Box::new(vec![dataset]))),
                 );
                 CmdResult::None
             }

--- a/examples/chart.rs
+++ b/examples/chart.rs
@@ -15,8 +15,7 @@ use tuirealm::ratatui::widgets::GraphType;
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
 use tuirealm::listener::{ListenerResult, Poll};
 use tuirealm::props::{
-    Alignment, AttrValue, Attribute, BorderType, Borders, Color, PropPayload,
-    Style,
+    Alignment, AttrValue, Attribute, BorderType, Borders, Color, PropPayload, Style,
 };
 use tuirealm::terminal::{CrosstermTerminalAdapter, TerminalBridge};
 use tuirealm::{

--- a/src/components/chart/chart.rs
+++ b/src/components/chart/chart.rs
@@ -128,7 +128,7 @@ impl Chart {
 
     /// Builder-Style function to set the initial data
     pub fn data(mut self, data: impl IntoIterator<Item = ChartDataset>) -> Self {
-        self.states.data = data.into_iter().collect();
+        self.set_data(data.into_iter().collect());
         self
     }
 
@@ -208,6 +208,11 @@ impl Chart {
         self
     }
 
+    fn set_data(&mut self, data: Vec<ChartDataset>) {
+        self.states.data = data;
+        self.states.reset_cursor();
+    }
+
     fn is_disabled(&self) -> bool {
         self.props
             .get_or(Attribute::Disabled, AttrValue::Flag(false))
@@ -248,8 +253,7 @@ impl Chart {
             AttrValue::Dataset(_) => unimplemented!(), // to be removed soon https://github.com/veeso/tui-realm/pull/139
             AttrValue::Payload(PropPayload::Any(val)) => {
                 if let Some(data) = Self::try_downcast(val) {
-                    self.states.data = data;
-                    self.states.reset_cursor();
+                    self.set_data(data);
                 }
             }
             _ => (),

--- a/src/components/chart/chart.rs
+++ b/src/components/chart/chart.rs
@@ -108,6 +108,7 @@ impl Chart {
         self
     }
 
+    /// Set a title for the Block
     pub fn title<S: Into<String>>(mut self, t: S, a: Alignment) -> Self {
         self.props
             .set(Attribute::Title, AttrValue::Title((t.into(), a)));
@@ -119,11 +120,13 @@ impl Chart {
         self
     }
 
+    /// Set the inactive style for the whole component
     pub fn inactive(mut self, s: Style) -> Self {
         self.props.set(Attribute::FocusStyle, AttrValue::Style(s));
         self
     }
 
+    /// Builder-Style function to set the initial data
     pub fn data(mut self, data: impl IntoIterator<Item = ChartDataset>) -> Self {
         self.states.data = data.into_iter().collect();
         self
@@ -187,6 +190,7 @@ impl Chart {
         self
     }
 
+    /// Give the X axis a title
     pub fn x_title<S: Into<String>>(mut self, t: S) -> Self {
         self.props.set(
             Attribute::Custom(CHART_X_TITLE),
@@ -195,6 +199,7 @@ impl Chart {
         self
     }
 
+    /// Give the Y axis a title
     pub fn y_title<S: Into<String>>(mut self, t: S) -> Self {
         self.props.set(
             Attribute::Custom(CHART_Y_TITLE),
@@ -209,8 +214,6 @@ impl Chart {
             .unwrap_flag()
     }
 
-    /// ### max_dataset_len
-    ///
     /// Get the maximum len among the datasets
     fn max_dataset_len(&self) -> usize {
         self.states
@@ -226,7 +229,7 @@ impl Chart {
         self.states
             .data
             .iter()
-            .map(|x| Self::get_tui_dataset(x, start))
+            .map(|x| x.as_tuichart(start))
             .collect()
     }
 
@@ -256,24 +259,6 @@ impl Chart {
     /// Clone our data into a [`AttrValue`].
     fn data_to_attr(&self) -> AttrValue {
         AttrValue::Payload(PropPayload::Any(Box::new(self.states.data.to_vec())))
-    }
-}
-
-impl<'a> Chart {
-    /// ### get_tui_dataset
-    ///
-    /// Create tui_dataset from dataset
-    /// Only elements from `start` to the end
-    fn get_tui_dataset(dataset: &'a ChartDataset, start: usize) -> TuiDataset<'a> {
-        let points = dataset.get_data();
-
-        // Prepare data storage
-        TuiDataset::default()
-            .name(dataset.name.clone())
-            .marker(dataset.marker)
-            .graph_type(dataset.graph_type)
-            .style(dataset.style)
-            .data(&points[start..])
     }
 }
 

--- a/src/components/chart/chart.rs
+++ b/src/components/chart/chart.rs
@@ -2,9 +2,11 @@
 //!
 //! A component to plot one or more dataset in a cartesian coordinate system
 
+use std::any::Any;
+
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
 use tuirealm::props::{
-    Alignment, AttrValue, Attribute, Borders, Color, Dataset, PropPayload, PropValue, Props, Style,
+    Alignment, AttrValue, Attribute, Borders, Color, PropPayload, PropValue, Props, Style,
 };
 use tuirealm::ratatui::text::Line;
 use tuirealm::ratatui::{
@@ -15,6 +17,7 @@ use tuirealm::ratatui::{
 use tuirealm::{Frame, MockComponent, State};
 
 // -- Props
+use super::dataset::ChartDataset;
 use crate::props::{
     CHART_X_BOUNDS, CHART_X_LABELS, CHART_X_STYLE, CHART_X_TITLE, CHART_Y_BOUNDS, CHART_Y_LABELS,
     CHART_Y_STYLE, CHART_Y_TITLE,
@@ -26,7 +29,7 @@ use crate::props::{
 #[derive(Default)]
 pub struct ChartStates {
     pub cursor: usize,
-    pub data: Vec<Dataset>,
+    pub data: Vec<ChartDataset>,
 }
 
 impl ChartStates {
@@ -121,13 +124,8 @@ impl Chart {
         self
     }
 
-    pub fn data(mut self, data: impl IntoIterator<Item = Dataset>) -> Self {
-        self.props.set(
-            Attribute::Dataset,
-            AttrValue::Payload(PropPayload::Vec(
-                data.into_iter().map(PropValue::Dataset).collect(),
-            )),
-        );
+    pub fn data(mut self, data: impl IntoIterator<Item = ChartDataset>) -> Self {
+        self.states.data = data.into_iter().collect();
         self
     }
 
@@ -215,39 +213,49 @@ impl Chart {
     ///
     /// Get the maximum len among the datasets
     fn max_dataset_len(&self) -> usize {
-        self.props
-            .get(Attribute::Dataset)
-            .and_then(|x| {
-                x.unwrap_payload()
-                    .unwrap_vec()
-                    .iter()
-                    .cloned()
-                    .map(|x| x.unwrap_dataset().get_data().len())
-                    .max()
-            })
+        self.states
+            .data
+            .iter()
+            .map(|v| v.get_data().len())
+            .max()
             .unwrap_or(0)
     }
 
-    /// ### data
-    ///
     /// Get data to be displayed, starting from provided index at `start`
-    fn get_data(&mut self, start: usize) -> Vec<TuiDataset<'_>> {
-        self.states.data = self
-            .props
-            .get(Attribute::Dataset)
-            .map(|x| {
-                x.unwrap_payload()
-                    .unwrap_vec()
-                    .into_iter()
-                    .map(|x| x.unwrap_dataset())
-                    .collect()
-            })
-            .unwrap_or_default();
+    fn get_tui_data(&mut self, start: usize) -> Vec<TuiDataset<'_>> {
         self.states
             .data
             .iter()
             .map(|x| Self::get_tui_dataset(x, start))
             .collect()
+    }
+
+    /// Try downcasting the given [`Box<Any>`] into a concrete type.
+    fn try_downcast(value: Box<dyn Any + Send + Sync>) -> Option<Vec<ChartDataset>> {
+        if let Ok(data) = value.downcast::<Vec<ChartDataset>>() {
+            Some(*data)
+        } else {
+            None
+        }
+    }
+
+    /// Get our data from a [`AttrValue`].
+    fn data_from_attr(&mut self, attr: AttrValue) {
+        match attr {
+            AttrValue::Dataset(_) => unimplemented!(), // to be removed soon https://github.com/veeso/tui-realm/pull/139
+            AttrValue::Payload(PropPayload::Any(val)) => {
+                if let Some(data) = Self::try_downcast(val) {
+                    self.states.data = data;
+                    self.states.reset_cursor();
+                }
+            }
+            _ => (),
+        }
+    }
+
+    /// Clone our data into a [`AttrValue`].
+    fn data_to_attr(&self) -> AttrValue {
+        AttrValue::Payload(PropPayload::Any(Box::new(self.states.data.to_vec())))
     }
 }
 
@@ -256,7 +264,7 @@ impl<'a> Chart {
     ///
     /// Create tui_dataset from dataset
     /// Only elements from `start` to the end
-    fn get_tui_dataset(dataset: &'a Dataset, start: usize) -> TuiDataset<'a> {
+    fn get_tui_dataset(dataset: &'a ChartDataset, start: usize) -> TuiDataset<'a> {
         let points = dataset.get_data();
 
         // Prepare data storage
@@ -365,7 +373,7 @@ impl MockComponent for Chart {
                 y_axis = y_axis.title(Span::styled(title, normal_style));
             }
             // Get data
-            let data: Vec<TuiDataset> = self.get_data(self.states.cursor);
+            let data: Vec<TuiDataset> = self.get_tui_data(self.states.cursor);
             // Build widget
             let widget: TuiChart = TuiChart::new(data)
                 .style(normal_style)
@@ -378,12 +386,19 @@ impl MockComponent for Chart {
     }
 
     fn query(&self, attr: Attribute) -> Option<AttrValue> {
+        if attr == Attribute::Dataset {
+            return Some(self.data_to_attr());
+        }
+
         self.props.get(attr)
     }
 
     fn attr(&mut self, attr: Attribute, value: AttrValue) {
+        if attr == Attribute::Dataset {
+            self.data_from_attr(value);
+            return;
+        }
         self.props.set(attr, value);
-        self.states.reset_cursor();
     }
 
     fn perform(&mut self, cmd: Cmd) -> CmdResult {
@@ -473,7 +488,7 @@ mod test {
             .y_style(Style::default().fg(Color::LightYellow))
             .y_title("Month")
             .data([
-                Dataset::default()
+                ChartDataset::default()
                     .name("Minimum")
                     .graph_type(GraphType::Scatter)
                     .marker(Marker::Braille)
@@ -492,7 +507,7 @@ mod test {
                         (10.0, 4.0),
                         (11.0, 0.0),
                     ]),
-                Dataset::default()
+                ChartDataset::default()
                     .name("Maximum")
                     .graph_type(GraphType::Line)
                     .marker(Marker::Dot)
@@ -538,21 +553,21 @@ mod test {
         // component funcs
         assert_eq!(component.max_dataset_len(), 12);
         assert_eq!(component.is_disabled(), false);
-        assert_eq!(component.get_data(2).len(), 2);
+        assert_eq!(component.get_tui_data(2).len(), 2);
 
-        let mut comp = Chart::default().data([Dataset::default()
+        let mut comp = Chart::default().data([ChartDataset::default()
             .name("Maximum")
             .graph_type(GraphType::Line)
             .marker(Marker::Dot)
             .style(Style::default().fg(Color::LightRed))
             .data(vec![(0.0, 7.0)])]);
-        assert!(!comp.get_data(0).is_empty());
+        assert!(!comp.get_tui_data(0).is_empty());
 
         // Update and test empty data
         component.states.cursor_at_end(12);
         component.attr(
             Attribute::Dataset,
-            AttrValue::Payload(PropPayload::Vec(vec![])),
+            AttrValue::Payload(PropPayload::Any(Box::new(Vec::<ChartDataset>::new()))),
         );
         assert_eq!(component.max_dataset_len(), 0);
         // Cursor is reset

--- a/src/components/chart/chart.rs
+++ b/src/components/chart/chart.rs
@@ -15,7 +15,7 @@ use tuirealm::ratatui::{
 use tuirealm::{Frame, MockComponent, State};
 
 // -- Props
-use super::props::{
+use crate::props::{
     CHART_X_BOUNDS, CHART_X_LABELS, CHART_X_STYLE, CHART_X_TITLE, CHART_Y_BOUNDS, CHART_Y_LABELS,
     CHART_Y_STYLE, CHART_Y_TITLE,
 };

--- a/src/components/chart/chart.rs
+++ b/src/components/chart/chart.rs
@@ -235,11 +235,11 @@ impl Chart {
 
     /// Try downcasting the given [`Box<Any>`] into a concrete type.
     fn try_downcast(value: Box<dyn Any + Send + Sync>) -> Option<Vec<ChartDataset>> {
-        if let Ok(data) = value.downcast::<Vec<ChartDataset>>() {
-            Some(*data)
-        } else {
-            None
-        }
+        value
+            .downcast::<Vec<ChartDataset>>()
+            .map(|v| *v)
+            .or_else(|value| value.downcast::<ChartDataset>().map(|v| vec![*v]))
+            .ok()
     }
 
     /// Get our data from a [`AttrValue`].
@@ -557,5 +557,37 @@ mod test {
         assert_eq!(component.max_dataset_len(), 0);
         // Cursor is reset
         assert_eq!(component.states.cursor, 0);
+    }
+
+    #[test]
+    fn allowed_dataset_attrs() {
+        let mut component = Chart::default();
+        assert!(component.states.data.is_empty());
+
+        // allow overwriting multiple datasets at once
+        component.attr(
+            Attribute::Dataset,
+            AttrValue::Payload(PropPayload::Any(Box::new(vec![ChartDataset::default()]))),
+        );
+        assert_eq!(component.states.data.len(), 1);
+
+        component.attr(
+            Attribute::Dataset,
+            AttrValue::Payload(PropPayload::Any(Box::new(vec![ChartDataset::default()]))),
+        );
+        assert_eq!(component.states.data.len(), 1);
+
+        // allow overwriting using with just one dataset
+        component.attr(
+            Attribute::Dataset,
+            AttrValue::Payload(PropPayload::Any(Box::new(ChartDataset::default()))),
+        );
+        assert_eq!(component.states.data.len(), 1);
+
+        component.attr(
+            Attribute::Dataset,
+            AttrValue::Payload(PropPayload::Any(Box::new(ChartDataset::default()))),
+        );
+        assert_eq!(component.states.data.len(), 1);
     }
 }

--- a/src/components/chart/dataset.rs
+++ b/src/components/chart/dataset.rs
@@ -1,0 +1,144 @@
+//! ## Dataset
+//!
+//! `Dataset` is a wrapper for tui dataset
+
+use tuirealm::props::Style;
+use tuirealm::ratatui::symbols::Marker;
+use tuirealm::ratatui::widgets::{Dataset as TuiDataset, GraphType};
+
+/// Dataset describes a set of data for a chart
+#[derive(Clone, Debug)]
+pub struct ChartDataset {
+    pub name: String,
+    pub marker: Marker,
+    pub graph_type: GraphType,
+    pub style: Style,
+    data: Vec<(f64, f64)>,
+}
+
+impl Default for ChartDataset {
+    fn default() -> Self {
+        Self {
+            name: String::default(),
+            marker: Marker::Dot,
+            graph_type: GraphType::Scatter,
+            style: Style::default(),
+            data: Vec::default(),
+        }
+    }
+}
+
+impl ChartDataset {
+    /// Set name for dataset
+    pub fn name<S: Into<String>>(mut self, s: S) -> Self {
+        self.name = s.into();
+        self
+    }
+
+    /// Set marker type for dataset
+    pub fn marker(mut self, m: Marker) -> Self {
+        self.marker = m;
+        self
+    }
+
+    /// Set graphtype for dataset
+    pub fn graph_type(mut self, g: GraphType) -> Self {
+        self.graph_type = g;
+        self
+    }
+
+    /// Set style for dataset
+    pub fn style(mut self, s: Style) -> Self {
+        self.style = s;
+        self
+    }
+
+    /// Set data for dataset; must be a vec of (f64, f64)
+    pub fn data(mut self, data: Vec<(f64, f64)>) -> Self {
+        self.data = data;
+        self
+    }
+
+    /// Push a record to the back of dataset
+    pub fn push(&mut self, point: (f64, f64)) {
+        self.data.push(point);
+    }
+
+    /// Pop last element of dataset
+    pub fn pop(&mut self) {
+        self.data.pop();
+    }
+
+    /// Pop last element of dataset
+    pub fn pop_front(&mut self) {
+        if !self.data.is_empty() {
+            self.data.remove(0);
+        }
+    }
+
+    /// Get a reference to data
+    pub fn get_data(&self) -> &[(f64, f64)] {
+        &self.data
+    }
+}
+
+impl PartialEq for ChartDataset {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name && self.data == other.data
+    }
+}
+
+impl<'a> From<&'a ChartDataset> for TuiDataset<'a> {
+    fn from(data: &'a ChartDataset) -> TuiDataset<'a> {
+        TuiDataset::default()
+            .name(data.name.clone())
+            .marker(data.marker)
+            .graph_type(data.graph_type)
+            .style(data.style)
+            .data(data.get_data())
+    }
+}
+
+#[cfg(test)]
+mod test {
+
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+    use tuirealm::ratatui::style::Color;
+
+    #[test]
+    fn dataset() {
+        let mut dataset: ChartDataset = ChartDataset::default()
+            .name("Avg temperatures")
+            .graph_type(GraphType::Scatter)
+            .marker(Marker::Braille)
+            .style(Style::default().fg(Color::Cyan))
+            .data(vec![
+                (0.0, -1.0),
+                (1.0, 1.0),
+                (2.0, 3.0),
+                (3.0, 7.0),
+                (4.0, 11.0),
+                (5.0, 15.0),
+                (6.0, 17.0),
+                (7.0, 17.0),
+                (8.0, 13.0),
+                (9.0, 9.0),
+                (10.0, 4.0),
+                (11.0, 0.0),
+            ]);
+        assert_eq!(dataset.name.as_str(), "Avg temperatures");
+        assert_eq!(dataset.style.fg.unwrap_or(Color::Reset), Color::Cyan);
+        assert_eq!(dataset.get_data().len(), 12);
+        // mut
+        dataset.push((12.0, 1.0));
+        assert_eq!(dataset.get_data().len(), 13);
+        dataset.pop();
+        assert_eq!(dataset.get_data().len(), 12);
+        dataset.pop_front();
+        assert_eq!(dataset.get_data().len(), 11);
+        // From
+        let _: TuiDataset = TuiDataset::from(&dataset);
+    }
+}

--- a/src/components/chart/dataset.rs
+++ b/src/components/chart/dataset.rs
@@ -80,6 +80,19 @@ impl ChartDataset {
     pub fn get_data(&self) -> &[(f64, f64)] {
         &self.data
     }
+
+    /// Create [`TuiDataset`] from the current [`ChartDataset`].
+    ///
+    /// Only elements from `start` are included.
+    pub fn as_tuichart<'a>(&'a self, start: usize) -> TuiDataset<'a> {
+        // Prepare data storage
+        TuiDataset::default()
+            .name(self.name.clone())
+            .marker(self.marker)
+            .graph_type(self.graph_type)
+            .style(self.style)
+            .data(&self.get_data()[start..])
+    }
 }
 
 impl PartialEq for ChartDataset {

--- a/src/components/chart/dataset.rs
+++ b/src/components/chart/dataset.rs
@@ -2,14 +2,14 @@
 //!
 //! `Dataset` is a wrapper for tui dataset
 
-use tuirealm::props::Style;
+use tuirealm::props::{LineStatic, Style};
 use tuirealm::ratatui::symbols::Marker;
 use tuirealm::ratatui::widgets::{Dataset as TuiDataset, GraphType};
 
 /// Dataset describes a set of data for a chart
 #[derive(Clone, Debug)]
 pub struct ChartDataset {
-    pub name: String,
+    pub name: LineStatic,
     pub marker: Marker,
     pub graph_type: GraphType,
     pub style: Style,
@@ -19,7 +19,7 @@ pub struct ChartDataset {
 impl Default for ChartDataset {
     fn default() -> Self {
         Self {
-            name: String::default(),
+            name: LineStatic::default(),
             marker: Marker::Dot,
             graph_type: GraphType::Scatter,
             style: Style::default(),
@@ -30,8 +30,8 @@ impl Default for ChartDataset {
 
 impl ChartDataset {
     /// Set name for dataset
-    pub fn name<S: Into<String>>(mut self, s: S) -> Self {
-        self.name = s.into();
+    pub fn name<S: Into<LineStatic>>(mut self, name: S) -> Self {
+        self.name = name.into();
         self
     }
 
@@ -141,7 +141,7 @@ mod test {
                 (10.0, 4.0),
                 (11.0, 0.0),
             ]);
-        assert_eq!(dataset.name.as_str(), "Avg temperatures");
+        assert_eq!(dataset.name.to_string(), "Avg temperatures");
         assert_eq!(dataset.style.fg.unwrap_or(Color::Reset), Color::Cyan);
         assert_eq!(dataset.get_data().len(), 12);
         // mut

--- a/src/components/chart/mod.rs
+++ b/src/components/chart/mod.rs
@@ -1,3 +1,6 @@
+#[expect(clippy::module_inception)]
 mod chart;
+mod dataset;
 
 pub use chart::{Chart, ChartStates};
+pub use dataset::ChartDataset;

--- a/src/components/chart/mod.rs
+++ b/src/components/chart/mod.rs
@@ -1,0 +1,3 @@
+mod chart;
+
+pub use chart::{Chart, ChartStates};

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -29,7 +29,7 @@ pub mod states;
 // Exports
 pub use bar_chart::BarChart;
 pub use canvas::Canvas;
-pub use chart::Chart;
+pub use chart::{Chart, ChartDataset};
 pub use checkbox::Checkbox;
 pub use container::Container;
 pub use input::Input;


### PR DESCRIPTION
# ISSUE _NUMBER_ - PULL_REQUEST_TITLE

~~Depends on #46~~
Re https://github.com/veeso/tui-realm/pull/139

## Description

This PR is implementing the `Dataset` directly, to be ahead of https://github.com/veeso/tui-realm/pull/139 and to showcase use without requiring it in core.
Additionally includes the following chart-related refactors:
- move some functions to where they should be
- add some more doc comments
- change `Dataset::name` to be `Line` to allow styling the name (and store static strings more efficiently)

I didnt want to include the dataset and the component in a single file, so i moved everything to be in a directory. I also didnt really wanna put the component into `mod.rs`, so i put it in `chart.rs` and made the `mod.rs` just be a re-export.

While doing this i noticed that the chart example has ways to move around the chart, but the Chart component only allows overwriting the dataset instead of appending to it, even while doing `chart.query() -> modify -> chart.attr()` it would always reset the cursor, and the example never stops appending data.
Should we implement a direct function to manipulate the dataset(s), bypassing the `query` / `attr` conversions and/or implement custom attributes to push data onto the dataset? (ex `Attribute::Custom("chart-dataset-push"), AttrValue::PropPayload(PropPayload::Any(CustomStruct{ idx: DATASET_IDX, data: DATATYPE }))`)

## Type of change

Please select relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no new *C-bindings*
- [x] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit
