### PR TITLE
Remove usage of core `Dataset`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ rust-version = "1.85.1"
 
 [dependencies]
 textwrap = "^0.16"
-tuirealm = { version = "3", default-features = false, features = ["derive"], git = "https://github.com/veeso/tui-realm.git", rev = "17ad10bd602d00cbe5e01b35db7dec6776509bb9" }
+tuirealm = { version = "3", default-features = false, features = ["derive"], git = "https://github.com/veeso/tui-realm.git", rev = "b140498e70c1fa5bcfe60eb6f4cbce02a1d82434" }
 unicode-width = "^0.2"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ rust-version = "1.85.1"
 
 [dependencies]
 textwrap = "^0.16"
-tuirealm = { version = "3", default-features = false, features = ["derive"], git = "https://github.com/veeso/tui-realm.git", rev = "b140498e70c1fa5bcfe60eb6f4cbce02a1d82434" }
+tuirealm = { version = "3", default-features = false, features = ["derive"], git = "https://github.com/veeso/tui-realm.git", rev = "5442cfb631ab01d8158fa91ca2168abe54891477" }
 unicode-width = "^0.2"
 
 [dev-dependencies]

--- a/examples/bar_chart.rs
+++ b/examples/bar_chart.rs
@@ -166,7 +166,7 @@ impl Default for ChartAlfa {
 }
 
 impl Component<Msg, NoUserEvent> for ChartAlfa {
-    fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
+    fn on(&mut self, ev: &Event<NoUserEvent>) -> Option<Msg> {
         let _ = match ev {
             Event::Keyboard(KeyEvent {
                 code: Key::Left, ..
@@ -231,7 +231,7 @@ impl Default for ChartBeta {
 }
 
 impl Component<Msg, NoUserEvent> for ChartBeta {
-    fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
+    fn on(&mut self, ev: &Event<NoUserEvent>) -> Option<Msg> {
         let _ = match ev {
             Event::Keyboard(KeyEvent {
                 code: Key::Left, ..

--- a/examples/canvas.rs
+++ b/examples/canvas.rs
@@ -165,7 +165,7 @@ impl Default for MyCanvas {
 }
 
 impl Component<Msg, NoUserEvent> for MyCanvas {
-    fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
+    fn on(&mut self, ev: &Event<NoUserEvent>) -> Option<Msg> {
         if let Event::Keyboard(KeyEvent { code: Key::Esc, .. }) = ev {
             Some(Msg::AppClose)
         } else {

--- a/examples/chart.rs
+++ b/examples/chart.rs
@@ -173,7 +173,7 @@ impl Default for ChartAlfa {
 }
 
 impl Component<Msg, UserEvent> for ChartAlfa {
-    fn on(&mut self, ev: Event<UserEvent>) -> Option<Msg> {
+    fn on(&mut self, ev: &Event<UserEvent>) -> Option<Msg> {
         let _ = match ev {
             Event::Keyboard(KeyEvent {
                 code: Key::Left, ..
@@ -195,7 +195,7 @@ impl Component<Msg, UserEvent> for ChartAlfa {
                     .graph_type(GraphType::Line)
                     .marker(Marker::Braille)
                     .style(Style::default().fg(Color::Cyan))
-                    .data(data);
+                    .data(data.clone());
                 self.attr(
                     Attribute::Dataset,
                     AttrValue::Payload(PropPayload::Any(Box::new(vec![dataset]))),

--- a/examples/checkbox.rs
+++ b/examples/checkbox.rs
@@ -169,7 +169,7 @@ impl Default for CheckboxAlfa {
 }
 
 impl Component<Msg, NoUserEvent> for CheckboxAlfa {
-    fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
+    fn on(&mut self, ev: &Event<NoUserEvent>) -> Option<Msg> {
         let _ = match ev {
             Event::Keyboard(KeyEvent {
                 code: Key::Left, ..
@@ -222,7 +222,7 @@ impl Default for CheckboxBeta {
 }
 
 impl Component<Msg, NoUserEvent> for CheckboxBeta {
-    fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
+    fn on(&mut self, ev: &Event<NoUserEvent>) -> Option<Msg> {
         let _ = match ev {
             Event::Keyboard(KeyEvent {
                 code: Key::Left, ..

--- a/examples/container.rs
+++ b/examples/container.rs
@@ -240,7 +240,7 @@ impl Default for MyContainer {
 }
 
 impl Component<Msg, NoUserEvent> for MyContainer {
-    fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
+    fn on(&mut self, ev: &Event<NoUserEvent>) -> Option<Msg> {
         let _ = match ev {
             Event::Keyboard(KeyEvent { code: Key::Esc, .. }) => return Some(Msg::AppClose),
             _ => CmdResult::None,

--- a/examples/input.rs
+++ b/examples/input.rs
@@ -212,7 +212,7 @@ impl Default for InputText {
 }
 
 impl Component<Msg, NoUserEvent> for InputText {
-    fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
+    fn on(&mut self, ev: &Event<NoUserEvent>) -> Option<Msg> {
         let _ = match ev {
             Event::Keyboard(KeyEvent {
                 code: Key::Left, ..
@@ -236,7 +236,7 @@ impl Component<Msg, NoUserEvent> for InputText {
             Event::Keyboard(KeyEvent {
                 code: Key::Char(ch),
                 modifiers: KeyModifiers::NONE,
-            }) => self.perform(Cmd::Type(ch)),
+            }) => self.perform(Cmd::Type(*ch)),
             Event::Keyboard(KeyEvent { code: Key::Tab, .. }) => return Some(Msg::TextBlur),
             Event::Keyboard(KeyEvent { code: Key::Esc, .. }) => return Some(Msg::AppClose),
             _ => CmdResult::None,
@@ -272,7 +272,7 @@ impl Default for InputEmail {
 }
 
 impl Component<Msg, NoUserEvent> for InputEmail {
-    fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
+    fn on(&mut self, ev: &Event<NoUserEvent>) -> Option<Msg> {
         let _ = match ev {
             Event::Keyboard(KeyEvent {
                 code: Key::Left, ..
@@ -296,7 +296,7 @@ impl Component<Msg, NoUserEvent> for InputEmail {
             Event::Keyboard(KeyEvent {
                 code: Key::Char(ch),
                 modifiers: KeyModifiers::NONE,
-            }) => self.perform(Cmd::Type(ch)),
+            }) => self.perform(Cmd::Type(*ch)),
             Event::Keyboard(KeyEvent { code: Key::Tab, .. }) => return Some(Msg::EmailBlur),
             Event::Keyboard(KeyEvent { code: Key::Esc, .. }) => return Some(Msg::AppClose),
             _ => CmdResult::None,
@@ -329,7 +329,7 @@ impl Default for InputNumber {
 }
 
 impl Component<Msg, NoUserEvent> for InputNumber {
-    fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
+    fn on(&mut self, ev: &Event<NoUserEvent>) -> Option<Msg> {
         let _ = match ev {
             Event::Keyboard(KeyEvent {
                 code: Key::Left, ..
@@ -353,7 +353,7 @@ impl Component<Msg, NoUserEvent> for InputNumber {
             Event::Keyboard(KeyEvent {
                 code: Key::Char(ch),
                 modifiers: KeyModifiers::NONE,
-            }) => self.perform(Cmd::Type(ch)),
+            }) => self.perform(Cmd::Type(*ch)),
             Event::Keyboard(KeyEvent { code: Key::Tab, .. }) => return Some(Msg::NumberBlur),
             Event::Keyboard(KeyEvent { code: Key::Esc, .. }) => return Some(Msg::AppClose),
             _ => CmdResult::None,
@@ -385,7 +385,7 @@ impl Default for InputPassword {
 }
 
 impl Component<Msg, NoUserEvent> for InputPassword {
-    fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
+    fn on(&mut self, ev: &Event<NoUserEvent>) -> Option<Msg> {
         let _ = match ev {
             Event::Keyboard(KeyEvent {
                 code: Key::Left, ..
@@ -409,7 +409,7 @@ impl Component<Msg, NoUserEvent> for InputPassword {
             Event::Keyboard(KeyEvent {
                 code: Key::Char(ch),
                 modifiers: KeyModifiers::NONE,
-            }) => self.perform(Cmd::Type(ch)),
+            }) => self.perform(Cmd::Type(*ch)),
             Event::Keyboard(KeyEvent { code: Key::Tab, .. }) => return Some(Msg::PasswordBlur),
             Event::Keyboard(KeyEvent { code: Key::Esc, .. }) => return Some(Msg::AppClose),
             _ => CmdResult::None,
@@ -446,7 +446,7 @@ impl Default for InputPhone {
 }
 
 impl Component<Msg, NoUserEvent> for InputPhone {
-    fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
+    fn on(&mut self, ev: &Event<NoUserEvent>) -> Option<Msg> {
         let _ = match ev {
             Event::Keyboard(KeyEvent {
                 code: Key::Left, ..
@@ -470,7 +470,7 @@ impl Component<Msg, NoUserEvent> for InputPhone {
             Event::Keyboard(KeyEvent {
                 code: Key::Char(ch),
                 modifiers: KeyModifiers::NONE,
-            }) => self.perform(Cmd::Type(ch)),
+            }) => self.perform(Cmd::Type(*ch)),
             Event::Keyboard(KeyEvent { code: Key::Tab, .. }) => return Some(Msg::PhoneBlur),
             Event::Keyboard(KeyEvent { code: Key::Esc, .. }) => return Some(Msg::AppClose),
             _ => CmdResult::None,
@@ -502,7 +502,7 @@ impl Default for InputColor {
 }
 
 impl Component<Msg, NoUserEvent> for InputColor {
-    fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
+    fn on(&mut self, ev: &Event<NoUserEvent>) -> Option<Msg> {
         let _ = match ev {
             Event::Keyboard(KeyEvent {
                 code: Key::Left, ..
@@ -528,7 +528,7 @@ impl Component<Msg, NoUserEvent> for InputColor {
                 modifiers: KeyModifiers::NONE,
             }) => {
                 if let CmdResult::Changed(State::One(StateValue::String(color))) =
-                    self.perform(Cmd::Type(ch))
+                    self.perform(Cmd::Type(*ch))
                 {
                     let color = tuirealm::utils::parser::parse_color(&color).unwrap();
                     self.attr(Attribute::Foreground, AttrValue::Color(color));

--- a/examples/label.rs
+++ b/examples/label.rs
@@ -142,7 +142,7 @@ impl Default for LabelAlfa {
 }
 
 impl Component<Msg, NoUserEvent> for LabelAlfa {
-    fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
+    fn on(&mut self, ev: &Event<NoUserEvent>) -> Option<Msg> {
         let _ = match ev {
             Event::Keyboard(KeyEvent { code: Key::Esc, .. }) => return Some(Msg::AppClose),
             _ => CmdResult::None,
@@ -170,7 +170,7 @@ impl Default for LabelBeta {
 }
 
 impl Component<Msg, NoUserEvent> for LabelBeta {
-    fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
+    fn on(&mut self, ev: &Event<NoUserEvent>) -> Option<Msg> {
         let _ = match ev {
             Event::Keyboard(KeyEvent { code: Key::Esc, .. }) => return Some(Msg::AppClose),
             _ => CmdResult::None,

--- a/examples/line_gauge.rs
+++ b/examples/line_gauge.rs
@@ -183,14 +183,14 @@ impl Default for GaugeAlfa {
 }
 
 impl Component<Msg, UserEvent> for GaugeAlfa {
-    fn on(&mut self, ev: Event<UserEvent>) -> Option<Msg> {
+    fn on(&mut self, ev: &Event<UserEvent>) -> Option<Msg> {
         let _ = match ev {
             Event::User(UserEvent::Loaded(prog)) => {
                 // Update
                 let label = format!("{:02}%", (prog * 100.0) as usize);
                 self.attr(
                     Attribute::Value,
-                    AttrValue::Payload(PropPayload::One(PropValue::F64(prog))),
+                    AttrValue::Payload(PropPayload::One(PropValue::F64(*prog))),
                 );
                 self.attr(Attribute::Text, AttrValue::String(label));
                 CmdResult::None
@@ -226,14 +226,14 @@ impl Default for GaugeBeta {
 }
 
 impl Component<Msg, UserEvent> for GaugeBeta {
-    fn on(&mut self, ev: Event<UserEvent>) -> Option<Msg> {
+    fn on(&mut self, ev: &Event<UserEvent>) -> Option<Msg> {
         let _ = match ev {
             Event::User(UserEvent::Loaded(prog)) => {
                 // Update
                 let label = format!("{:02}%", (prog * 100.0) as usize);
                 self.attr(
                     Attribute::Value,
-                    AttrValue::Payload(PropPayload::One(PropValue::F64(prog))),
+                    AttrValue::Payload(PropPayload::One(PropValue::F64(*prog))),
                 );
                 self.attr(Attribute::Text, AttrValue::String(label));
                 CmdResult::None

--- a/examples/list.rs
+++ b/examples/list.rs
@@ -229,7 +229,7 @@ impl Default for ListAlfa {
 }
 
 impl Component<Msg, NoUserEvent> for ListAlfa {
-    fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
+    fn on(&mut self, ev: &Event<NoUserEvent>) -> Option<Msg> {
         let _ = match ev {
             Event::Keyboard(KeyEvent {
                 code: Key::Down, ..
@@ -347,7 +347,7 @@ impl Default for ListBeta {
 }
 
 impl Component<Msg, NoUserEvent> for ListBeta {
-    fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
+    fn on(&mut self, ev: &Event<NoUserEvent>) -> Option<Msg> {
         let _ = match ev {
             Event::Keyboard(KeyEvent { code: Key::Tab, .. }) => return Some(Msg::ListBetaBlur),
             Event::Keyboard(KeyEvent { code: Key::Esc, .. }) => return Some(Msg::AppClose),

--- a/examples/paragraph.rs
+++ b/examples/paragraph.rs
@@ -162,7 +162,7 @@ impl Default for ParagraphAlfa {
 }
 
 impl Component<Msg, NoUserEvent> for ParagraphAlfa {
-    fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
+    fn on(&mut self, ev: &Event<NoUserEvent>) -> Option<Msg> {
         let _ = match ev {
             Event::Keyboard(KeyEvent { code: Key::Esc, .. }) => return Some(Msg::AppClose),
             _ => CmdResult::None,
@@ -199,7 +199,7 @@ impl Default for ParagraphBeta {
 }
 
 impl Component<Msg, NoUserEvent> for ParagraphBeta {
-    fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
+    fn on(&mut self, ev: &Event<NoUserEvent>) -> Option<Msg> {
         let _ = match ev {
             Event::Keyboard(KeyEvent { code: Key::Esc, .. }) => return Some(Msg::AppClose),
             _ => CmdResult::None,

--- a/examples/progress_bar.rs
+++ b/examples/progress_bar.rs
@@ -182,7 +182,7 @@ impl Default for KeyboardLabel {
 }
 
 impl Component<Msg, UserEvent> for KeyboardLabel {
-    fn on(&mut self, _: Event<UserEvent>) -> Option<Msg> {
+    fn on(&mut self, _: &Event<UserEvent>) -> Option<Msg> {
         None
     }
 }
@@ -210,14 +210,14 @@ impl Default for GaugeAlfa {
 }
 
 impl Component<Msg, UserEvent> for GaugeAlfa {
-    fn on(&mut self, ev: Event<UserEvent>) -> Option<Msg> {
+    fn on(&mut self, ev: &Event<UserEvent>) -> Option<Msg> {
         let _ = match ev {
             Event::User(UserEvent::Loaded(prog)) => {
                 // Update
                 let label = format!("{:02}%", (prog * 100.0) as usize);
                 self.attr(
                     Attribute::Value,
-                    AttrValue::Payload(PropPayload::One(PropValue::F64(prog))),
+                    AttrValue::Payload(PropPayload::One(PropValue::F64(*prog))),
                 );
                 self.attr(Attribute::Text, AttrValue::String(label));
                 CmdResult::None
@@ -253,7 +253,7 @@ impl Default for GaugeBeta {
 }
 
 impl Component<Msg, UserEvent> for GaugeBeta {
-    fn on(&mut self, ev: Event<UserEvent>) -> Option<Msg> {
+    fn on(&mut self, ev: &Event<UserEvent>) -> Option<Msg> {
         let _ = match ev {
             Event::User(UserEvent::Loaded(_)) => {
                 let mut prog = self

--- a/examples/radio.rs
+++ b/examples/radio.rs
@@ -166,7 +166,7 @@ impl Default for RadioAlfa {
 }
 
 impl Component<Msg, NoUserEvent> for RadioAlfa {
-    fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
+    fn on(&mut self, ev: &Event<NoUserEvent>) -> Option<Msg> {
         let _ = match ev {
             Event::Keyboard(KeyEvent {
                 code: Key::Left, ..
@@ -214,7 +214,7 @@ impl Default for RadioBeta {
 }
 
 impl Component<Msg, NoUserEvent> for RadioBeta {
-    fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
+    fn on(&mut self, ev: &Event<NoUserEvent>) -> Option<Msg> {
         let _ = match ev {
             Event::Keyboard(KeyEvent {
                 code: Key::Left, ..

--- a/examples/select.rs
+++ b/examples/select.rs
@@ -179,7 +179,7 @@ impl Default for SelectAlfa {
 }
 
 impl Component<Msg, NoUserEvent> for SelectAlfa {
-    fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
+    fn on(&mut self, ev: &Event<NoUserEvent>) -> Option<Msg> {
         let _ = match ev {
             Event::Keyboard(KeyEvent {
                 code: Key::Down, ..
@@ -233,7 +233,7 @@ impl Default for SelectBeta {
 }
 
 impl Component<Msg, NoUserEvent> for SelectBeta {
-    fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
+    fn on(&mut self, ev: &Event<NoUserEvent>) -> Option<Msg> {
         let _ = match ev {
             Event::Keyboard(KeyEvent {
                 code: Key::Down, ..

--- a/examples/span.rs
+++ b/examples/span.rs
@@ -146,7 +146,7 @@ impl Default for SpanAlfa {
 }
 
 impl Component<Msg, NoUserEvent> for SpanAlfa {
-    fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
+    fn on(&mut self, ev: &Event<NoUserEvent>) -> Option<Msg> {
         let _ = match ev {
             Event::Keyboard(KeyEvent { code: Key::Esc, .. }) => return Some(Msg::AppClose),
             _ => CmdResult::None,
@@ -177,7 +177,7 @@ impl Default for SpanBeta {
 }
 
 impl Component<Msg, NoUserEvent> for SpanBeta {
-    fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
+    fn on(&mut self, ev: &Event<NoUserEvent>) -> Option<Msg> {
         let _ = match ev {
             Event::Keyboard(KeyEvent { code: Key::Esc, .. }) => return Some(Msg::AppClose),
             _ => CmdResult::None,

--- a/examples/sparkline.rs
+++ b/examples/sparkline.rs
@@ -162,11 +162,11 @@ impl Default for SparklineAlfa {
 }
 
 impl Component<Msg, UserEvent> for SparklineAlfa {
-    fn on(&mut self, ev: Event<UserEvent>) -> Option<Msg> {
+    fn on(&mut self, ev: &Event<UserEvent>) -> Option<Msg> {
         let _ = match ev {
             Event::Keyboard(KeyEvent { code: Key::Esc, .. }) => return Some(Msg::AppClose),
             Event::User(UserEvent::DataGenerated(data)) => {
-                let data: Vec<PropValue> = data.into_iter().map(PropValue::U64).collect();
+                let data: Vec<PropValue> = data.iter().copied().map(PropValue::U64).collect();
                 self.attr(
                     Attribute::Dataset,
                     AttrValue::Payload(PropPayload::Vec(data)),

--- a/examples/spinner.rs
+++ b/examples/spinner.rs
@@ -172,7 +172,7 @@ impl Default for SpanAlfa {
 }
 
 impl Component<Msg, NoUserEvent> for SpanAlfa {
-    fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
+    fn on(&mut self, ev: &Event<NoUserEvent>) -> Option<Msg> {
         let _ = match ev {
             Event::Keyboard(KeyEvent { code: Key::Esc, .. }) => return Some(Msg::AppClose),
             _ => CmdResult::None,
@@ -208,7 +208,7 @@ impl Default for SpanBeta {
 }
 
 impl Component<Msg, NoUserEvent> for SpanBeta {
-    fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
+    fn on(&mut self, ev: &Event<NoUserEvent>) -> Option<Msg> {
         let _ = match ev {
             Event::Keyboard(KeyEvent { code: Key::Esc, .. }) => return Some(Msg::AppClose),
             _ => CmdResult::None,
@@ -234,8 +234,8 @@ impl Default for SpinnerAlfa {
 }
 
 impl Component<Msg, NoUserEvent> for SpinnerAlfa {
-    fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
-        if ev == Event::Tick {
+    fn on(&mut self, ev: &Event<NoUserEvent>) -> Option<Msg> {
+        if *ev == Event::Tick {
             self.component.states.step();
         }
 
@@ -259,7 +259,7 @@ impl Default for SpinnerBeta {
 }
 
 impl Component<Msg, NoUserEvent> for SpinnerBeta {
-    fn on(&mut self, _: Event<NoUserEvent>) -> Option<Msg> {
+    fn on(&mut self, _: &Event<NoUserEvent>) -> Option<Msg> {
         None
     }
 }

--- a/examples/table.rs
+++ b/examples/table.rs
@@ -197,7 +197,7 @@ impl Default for TableAlfa {
 }
 
 impl Component<Msg, NoUserEvent> for TableAlfa {
-    fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
+    fn on(&mut self, ev: &Event<NoUserEvent>) -> Option<Msg> {
         let _ = match ev {
             Event::Keyboard(KeyEvent {
                 code: Key::Down, ..
@@ -286,7 +286,7 @@ impl Default for TableBeta {
 }
 
 impl Component<Msg, NoUserEvent> for TableBeta {
-    fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
+    fn on(&mut self, ev: &Event<NoUserEvent>) -> Option<Msg> {
         let _ = match ev {
             Event::Keyboard(KeyEvent { code: Key::Tab, .. }) => return Some(Msg::TableBetaBlur),
             Event::Keyboard(KeyEvent { code: Key::Esc, .. }) => return Some(Msg::AppClose),

--- a/examples/textarea.rs
+++ b/examples/textarea.rs
@@ -176,7 +176,7 @@ impl Default for TextareaAlfa {
 }
 
 impl Component<Msg, NoUserEvent> for TextareaAlfa {
-    fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
+    fn on(&mut self, ev: &Event<NoUserEvent>) -> Option<Msg> {
         let _ = match ev {
             Event::Keyboard(KeyEvent {
                 code: Key::Down, ..
@@ -242,7 +242,7 @@ impl Default for TextareaBeta {
 }
 
 impl Component<Msg, NoUserEvent> for TextareaBeta {
-    fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
+    fn on(&mut self, ev: &Event<NoUserEvent>) -> Option<Msg> {
         let _ = match ev {
             Event::Keyboard(KeyEvent {
                 code: Key::Down, ..

--- a/src/components/bar_chart.rs
+++ b/src/components/bar_chart.rs
@@ -121,7 +121,7 @@ impl BarChart {
     pub fn data(mut self, data: &[(&str, u64)]) -> Self {
         let mut list: LinkedList<PropPayload> = LinkedList::new();
         for (a, b) in data {
-            list.push_back(PropPayload::Tup2((
+            list.push_back(PropPayload::Pair((
                 PropValue::Str((*a).to_string()),
                 PropValue::U64(*b),
             )));
@@ -200,7 +200,7 @@ impl BarChart {
                     continue;
                 }
                 // Push item
-                if let PropPayload::Tup2((PropValue::Str(label), PropValue::U64(value))) = item {
+                if let PropPayload::Pair((PropValue::Str(label), PropValue::U64(value))) = item {
                     data.push((label.clone(), *value));
                 }
                 // Break

--- a/src/components/canvas.rs
+++ b/src/components/canvas.rs
@@ -76,7 +76,7 @@ impl Canvas {
     pub fn x_bounds(mut self, bounds: (f64, f64)) -> Self {
         self.attr(
             Attribute::Custom(CANVAS_X_BOUNDS),
-            AttrValue::Payload(PropPayload::Tup2((
+            AttrValue::Payload(PropPayload::Pair((
                 PropValue::F64(bounds.0),
                 PropValue::F64(bounds.1),
             ))),
@@ -93,7 +93,7 @@ impl Canvas {
     pub fn y_bounds(mut self, bounds: (f64, f64)) -> Self {
         self.attr(
             Attribute::Custom(CANVAS_Y_BOUNDS),
-            AttrValue::Payload(PropPayload::Tup2((
+            AttrValue::Payload(PropPayload::Pair((
                 PropValue::F64(bounds.0),
                 PropValue::F64(bounds.1),
             ))),
@@ -182,12 +182,12 @@ impl MockComponent for Canvas {
             let x_bounds: [f64; 2] = self
                 .props
                 .get(Attribute::Custom(CANVAS_X_BOUNDS))
-                .map(|x| x.unwrap_payload().unwrap_tup2())
+                .map(|x| x.unwrap_payload().unwrap_pair())
                 .map_or([0.0, 0.0], |(a, b)| [a.unwrap_f64(), b.unwrap_f64()]);
             let y_bounds: [f64; 2] = self
                 .props
                 .get(Attribute::Custom(CANVAS_Y_BOUNDS))
-                .map(|x| x.unwrap_payload().unwrap_tup2())
+                .map(|x| x.unwrap_payload().unwrap_pair())
                 .map_or([0.0, 0.0], |(a, b)| [a.unwrap_f64(), b.unwrap_f64()]);
             // Get shapes
             let shapes: Vec<Shape> = self

--- a/src/components/chart/chart.rs
+++ b/src/components/chart/chart.rs
@@ -247,14 +247,10 @@ impl Chart {
 
     /// Get our data from a [`AttrValue`].
     fn data_from_attr(&mut self, attr: AttrValue) {
-        match attr {
-            AttrValue::Dataset(_) => unimplemented!(), // to be removed soon https://github.com/veeso/tui-realm/pull/139
-            AttrValue::Payload(PropPayload::Any(val)) => {
-                if let Some(data) = Self::try_downcast(val) {
-                    self.set_data(data);
-                }
+        if let AttrValue::Payload(PropPayload::Any(val)) = attr {
+            if let Some(data) = Self::try_downcast(val) {
+                self.set_data(data);
             }
-            _ => (),
         }
     }
 

--- a/src/components/chart/chart.rs
+++ b/src/components/chart/chart.rs
@@ -133,7 +133,7 @@ impl Chart {
     pub fn x_bounds(mut self, bounds: (f64, f64)) -> Self {
         self.props.set(
             Attribute::Custom(CHART_X_BOUNDS),
-            AttrValue::Payload(PropPayload::Tup2((
+            AttrValue::Payload(PropPayload::Pair((
                 PropValue::F64(bounds.0),
                 PropValue::F64(bounds.1),
             ))),
@@ -144,7 +144,7 @@ impl Chart {
     pub fn y_bounds(mut self, bounds: (f64, f64)) -> Self {
         self.props.set(
             Attribute::Custom(CHART_Y_BOUNDS),
-            AttrValue::Payload(PropPayload::Tup2((
+            AttrValue::Payload(PropPayload::Pair((
                 PropValue::F64(bounds.0),
                 PropValue::F64(bounds.1),
             ))),
@@ -302,7 +302,7 @@ impl MockComponent for Chart {
             if let Some((PropValue::F64(floor), PropValue::F64(ceil))) = self
                 .props
                 .get(Attribute::Custom(CHART_X_BOUNDS))
-                .map(|x| x.unwrap_payload().unwrap_tup2())
+                .map(|x| x.unwrap_payload().unwrap_pair())
             {
                 let why_using_vecs_when_you_can_use_useless_arrays: [f64; 2] = [floor, ceil];
                 x_axis = x_axis.bounds(why_using_vecs_when_you_can_use_useless_arrays);
@@ -333,7 +333,7 @@ impl MockComponent for Chart {
             if let Some((PropValue::F64(floor), PropValue::F64(ceil))) = self
                 .props
                 .get(Attribute::Custom(CHART_Y_BOUNDS))
-                .map(|x| x.unwrap_payload().unwrap_tup2())
+                .map(|x| x.unwrap_payload().unwrap_pair())
             {
                 let why_using_vecs_when_you_can_use_useless_arrays: [f64; 2] = [floor, ceil];
                 y_axis = y_axis.bounds(why_using_vecs_when_you_can_use_useless_arrays);


### PR DESCRIPTION
# ISSUE _NUMBER_ - PULL_REQUEST_TITLE

Depends on ~~#49 and #51~~

## Description

Update STDLIB for the removal of `Dataset` in core: https://github.com/veeso/tui-realm/pull/139

## Type of change

Please select relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no new *C-bindings*
- [x] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit
