### PR TITLE
Apply changes for ratatui 0.30

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ keywords = ["tui", "terminal"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/veeso/tui-realm-stdlib"
-rust-version = "1.85.1"
+rust-version = "1.86"
 
 [dependencies]
 textwrap = "^0.16"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ rust-version = "1.86"
 
 [dependencies]
 textwrap = "^0.16"
-tuirealm = { version = "3", default-features = false, features = ["derive"], git = "https://github.com/veeso/tui-realm.git", rev = "78ebc9a6a1a6690009e72547039deabcc3776488" }
+tuirealm = { version = "3", default-features = false, features = ["derive"], git = "https://github.com/veeso/tui-realm.git", rev = "0b9048532524d11be3e77067e07b70338999c7b8" }
 unicode-width = "^0.2"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ rust-version = "1.86"
 
 [dependencies]
 textwrap = "^0.16"
-tuirealm = { version = "3", default-features = false, features = ["derive"], git = "https://github.com/veeso/tui-realm.git", rev = "5442cfb631ab01d8158fa91ca2168abe54891477" }
+tuirealm = { version = "3", default-features = false, features = ["derive"], git = "https://github.com/veeso/tui-realm.git", rev = "78ebc9a6a1a6690009e72547039deabcc3776488" }
 unicode-width = "^0.2"
 
 [dev-dependencies]

--- a/examples/line_gauge.rs
+++ b/examples/line_gauge.rs
@@ -3,16 +3,18 @@
 //! `Demo` shows how to use tui-realm in a real case
 
 mod utils;
+use tuirealm::ratatui::symbols::line::{HORIZONTAL, THICK_HORIZONTAL};
+use tuirealm::ratatui::text::Span;
 use utils::Loader;
 
 use std::time::Duration;
 
 use tui_realm_stdlib::LineGauge;
-use tui_realm_stdlib::props::LINE_GAUGE_STYLE_THICK;
 use tuirealm::command::CmdResult;
 use tuirealm::listener::{ListenerResult, Poll};
 use tuirealm::props::{
-    Alignment, AttrValue, Attribute, BorderType, Borders, Color, PropPayload, PropValue, Title,
+    Alignment, AttrValue, Attribute, BorderType, Borders, Color, PropPayload, PropValue, Style,
+    Title,
 };
 use tuirealm::terminal::{CrosstermTerminalAdapter, TerminalBridge};
 use tuirealm::{
@@ -176,7 +178,7 @@ impl Default for GaugeAlfa {
                 .foreground(Color::Green)
                 .label("0%")
                 .title(Title::from("Loading...").alignment(Alignment::Center))
-                .style(LINE_GAUGE_STYLE_THICK)
+                .line_style(THICK_HORIZONTAL, HORIZONTAL)
                 .progress(0.0),
         }
     }
@@ -220,6 +222,10 @@ impl Default for GaugeBeta {
                 .foreground(Color::Blue)
                 .label("0%")
                 .title(Title::from("Loading...").alignment(Alignment::Center))
+                .line_style(
+                    Span::styled(HORIZONTAL, Style::new().fg(Color::Red)),
+                    Span::styled(HORIZONTAL, Style::new().fg(Color::Gray)),
+                )
                 .progress(0.0),
         }
     }

--- a/src/components/canvas.rs
+++ b/src/components/canvas.rs
@@ -17,8 +17,8 @@ use tuirealm::{Frame, MockComponent, State};
 
 // -- Props
 use super::props::{
-    CANVAS_MARKER, CANVAS_MARKER_BLOCK, CANVAS_MARKER_BRAILLE, CANVAS_MARKER_DOT, CANVAS_X_BOUNDS,
-    CANVAS_Y_BOUNDS,
+    CANVAS_MARKER, CANVAS_MARKER_BAR, CANVAS_MARKER_BLOCK, CANVAS_MARKER_BRAILLE,
+    CANVAS_MARKER_DOT, CANVAS_MARKER_HALF_BLOCK, CANVAS_X_BOUNDS, CANVAS_Y_BOUNDS,
 };
 
 // -- Component
@@ -112,8 +112,8 @@ impl Canvas {
 
     fn marker_to_prop(marker: Marker) -> AttrValue {
         AttrValue::Number(match marker {
-            Marker::HalfBlock => crate::props::CANVAS_MARKER_HALF_BLOCK,
-            Marker::Bar => crate::props::CANVAS_MARKER_BAR,
+            Marker::HalfBlock => CANVAS_MARKER_HALF_BLOCK,
+            Marker::Bar => CANVAS_MARKER_BAR,
             Marker::Block => CANVAS_MARKER_BLOCK,
             Marker::Braille => CANVAS_MARKER_BRAILLE,
             Marker::Dot => CANVAS_MARKER_DOT,
@@ -131,7 +131,10 @@ impl Canvas {
         {
             CANVAS_MARKER_BLOCK => Marker::Block,
             CANVAS_MARKER_DOT => Marker::Dot,
-            _ => Marker::Braille,
+            CANVAS_MARKER_BRAILLE => Marker::Braille,
+            CANVAS_MARKER_BAR => Marker::Bar,
+            CANVAS_MARKER_HALF_BLOCK => Marker::HalfBlock,
+            num => unimplemented!("Mapping: {:#?}", num),
         }
     }
 

--- a/src/components/canvas.rs
+++ b/src/components/canvas.rs
@@ -18,7 +18,8 @@ use tuirealm::{Frame, MockComponent, State};
 // -- Props
 use super::props::{
     CANVAS_MARKER, CANVAS_MARKER_BAR, CANVAS_MARKER_BLOCK, CANVAS_MARKER_BRAILLE,
-    CANVAS_MARKER_DOT, CANVAS_MARKER_HALF_BLOCK, CANVAS_X_BOUNDS, CANVAS_Y_BOUNDS,
+    CANVAS_MARKER_DOT, CANVAS_MARKER_HALF_BLOCK, CANVAS_MARKER_OCTANT, CANVAS_MARKER_QUADRANT,
+    CANVAS_MARKER_SEXTANT, CANVAS_X_BOUNDS, CANVAS_Y_BOUNDS,
 };
 
 // -- Component
@@ -117,6 +118,10 @@ impl Canvas {
             Marker::Block => CANVAS_MARKER_BLOCK,
             Marker::Braille => CANVAS_MARKER_BRAILLE,
             Marker::Dot => CANVAS_MARKER_DOT,
+            Marker::Quadrant => CANVAS_MARKER_QUADRANT,
+            Marker::Sextant => CANVAS_MARKER_SEXTANT,
+            Marker::Octant => CANVAS_MARKER_OCTANT,
+            marker => unimplemented!("{:#?}", marker),
         })
     }
 
@@ -134,6 +139,9 @@ impl Canvas {
             CANVAS_MARKER_BRAILLE => Marker::Braille,
             CANVAS_MARKER_BAR => Marker::Bar,
             CANVAS_MARKER_HALF_BLOCK => Marker::HalfBlock,
+            CANVAS_MARKER_QUADRANT => Marker::Quadrant,
+            CANVAS_MARKER_SEXTANT => Marker::Sextant,
+            CANVAS_MARKER_OCTANT => Marker::Octant,
             num => unimplemented!("Mapping: {:#?}", num),
         }
     }

--- a/src/components/line_gauge.rs
+++ b/src/components/line_gauge.rs
@@ -79,7 +79,7 @@ impl LineGauge {
         self
     }
 
-    fn line_set(&self) -> Set {
+    fn line_set(&'_ self) -> Set<'_> {
         match self
             .props
             .get_or(
@@ -171,7 +171,9 @@ impl MockComponent for LineGauge {
                     .block(div)
                     .style(normal_style)
                     .filled_style(normal_style)
-                    .line_set(self.line_set())
+                    .filled_symbol(self.line_set().horizontal)
+                    // TODO: allow styling unfilled style
+                    // .unfilled_symbol(self.line_set().horizontal)
                     .label(label)
                     .ratio(percentage),
                 area,

--- a/src/components/line_gauge.rs
+++ b/src/components/line_gauge.rs
@@ -2,21 +2,13 @@
 //!
 //! `LineGauge` is a line gauge
 
-use super::props::{
-    LINE_GAUGE_STYLE_DOUBLE, LINE_GAUGE_STYLE_NORMAL, LINE_GAUGE_STYLE_ROUND,
-    LINE_GAUGE_STYLE_THICK,
-};
-
 use tuirealm::command::{Cmd, CmdResult};
 use tuirealm::props::{
-    AttrValue, Attribute, Borders, Color, PropPayload, PropValue, Props, Style, TextModifiers,
-    Title,
+    AttrValue, Attribute, Borders, Color, PropPayload, PropValue, Props, SpanStatic, Style,
+    TextModifiers, Title,
 };
-use tuirealm::ratatui::{
-    layout::Rect,
-    symbols::line::{DOUBLE, NORMAL, ROUNDED, Set, THICK},
-    widgets::LineGauge as TuiLineGauge,
-};
+use tuirealm::ratatui::text::Span;
+use tuirealm::ratatui::{layout::Rect, widgets::LineGauge as TuiLineGauge};
 use tuirealm::{Frame, MockComponent, State};
 
 // -- Component
@@ -70,42 +62,31 @@ impl LineGauge {
         self
     }
 
-    pub fn style(mut self, s: u8) -> Self {
-        Self::assert_line_style(s);
+    /// Set custom Style & Symbols for the filled & unfilled styles.
+    ///
+    /// By default ratatui uses [`HORIZONTAL`](tuirealm::ratatui::symbols::line::HORIZONTAL) for *both*.
+    pub fn line_style<F: Into<SpanStatic>, U: Into<SpanStatic>>(
+        mut self,
+        filled: F,
+        unfilled: U,
+    ) -> Self {
         self.attr(
-            Attribute::Style,
-            AttrValue::Payload(PropPayload::One(PropValue::U8(s))),
+            Attribute::HighlightedStr,
+            AttrValue::Payload(PropPayload::Pair((
+                PropValue::TextSpan(filled.into()),
+                PropValue::TextSpan(unfilled.into()),
+            ))),
         );
+
         self
     }
 
-    fn line_set(&'_ self) -> Set<'_> {
-        match self
-            .props
-            .get_or(
-                Attribute::Style,
-                AttrValue::Payload(PropPayload::One(PropValue::U8(LINE_GAUGE_STYLE_NORMAL))),
-            )
-            .unwrap_payload()
-        {
-            PropPayload::One(PropValue::U8(LINE_GAUGE_STYLE_DOUBLE)) => DOUBLE,
-            PropPayload::One(PropValue::U8(LINE_GAUGE_STYLE_ROUND)) => ROUNDED,
-            PropPayload::One(PropValue::U8(LINE_GAUGE_STYLE_THICK)) => THICK,
-            _ => NORMAL,
-        }
-    }
-
-    fn assert_line_style(s: u8) {
-        if !(&[
-            LINE_GAUGE_STYLE_DOUBLE,
-            LINE_GAUGE_STYLE_NORMAL,
-            LINE_GAUGE_STYLE_ROUND,
-            LINE_GAUGE_STYLE_THICK,
-        ]
-        .contains(&s))
-        {
-            panic!("Invalid line style");
-        }
+    fn get_line_style(&self) -> Option<(&Span<'_>, &Span<'_>)> {
+        self.props
+            .get_ref(Attribute::HighlightedStr)
+            .and_then(AttrValue::as_payload)
+            .and_then(PropPayload::as_pair)
+            .and_then(|pair| Some((pair.0.as_textspan()?, pair.1.as_textspan()?)))
     }
 
     fn assert_progress(p: f64) {
@@ -165,19 +146,24 @@ impl MockComponent for LineGauge {
                 .add_modifier(modifiers);
 
             let div = crate::utils::get_block(borders, title, true, None);
+
+            let mut line_guage = TuiLineGauge::default()
+                .block(div)
+                .style(normal_style)
+                .filled_style(normal_style)
+                .label(label)
+                .ratio(percentage);
+
+            if let Some(line_style) = self.get_line_style() {
+                line_guage = line_guage
+                    .filled_symbol(&line_style.0.content)
+                    .filled_style(line_style.0.style)
+                    .unfilled_symbol(&line_style.1.content)
+                    .unfilled_style(line_style.1.style);
+            }
+
             // Make progress bar
-            render.render_widget(
-                TuiLineGauge::default()
-                    .block(div)
-                    .style(normal_style)
-                    .filled_style(normal_style)
-                    .filled_symbol(self.line_set().horizontal)
-                    // TODO: allow styling unfilled style
-                    // .unfilled_symbol(self.line_set().horizontal)
-                    .label(label)
-                    .ratio(percentage),
-                area,
-            );
+            render.render_widget(line_guage, area);
         }
     }
 
@@ -186,11 +172,6 @@ impl MockComponent for LineGauge {
     }
 
     fn attr(&mut self, attr: Attribute, value: AttrValue) {
-        if let Attribute::Style = attr {
-            if let AttrValue::Payload(s) = value.clone() {
-                Self::assert_line_style(s.unwrap_one().unwrap_u8());
-            }
-        }
         if let Attribute::Value = attr {
             if let AttrValue::Payload(p) = value.clone() {
                 Self::assert_progress(p.unwrap_one().unwrap_f64());
@@ -214,7 +195,10 @@ mod test {
     use super::*;
 
     use pretty_assertions::assert_eq;
-    use tuirealm::props::Alignment;
+    use tuirealm::{
+        props::{Alignment, BorderType},
+        ratatui::symbols::line::{DOUBLE_HORIZONTAL, HORIZONTAL},
+    };
 
     #[test]
     fn test_components_progress_bar() {
@@ -224,7 +208,7 @@ mod test {
             .progress(0.60)
             .title(Title::from("Downloading file...").alignment(Alignment::Center))
             .label("60% - ETA 00:20")
-            .style(LINE_GAUGE_STYLE_DOUBLE)
+            .line_style(DOUBLE_HORIZONTAL, HORIZONTAL)
             .borders(Borders::default());
         // Get value
         assert_eq!(component.state(), State::None);
@@ -243,14 +227,20 @@ mod test {
     }
 
     #[test]
-    #[should_panic = "Invalid line style"]
-    fn line_gauge_bad_symbol() {
+    fn should_allow_styling_line() {
         let _ = LineGauge::default()
-            .background(Color::Red)
-            .foreground(Color::White)
-            .style(254)
-            .title(Title::from("Downloading file...").alignment(Alignment::Center))
-            .label("60% - ETA 00:20")
-            .borders(Borders::default());
+            .borders(
+                Borders::default()
+                    .color(Color::Blue)
+                    .modifiers(BorderType::Rounded),
+            )
+            .foreground(Color::Blue)
+            .label("0%")
+            .title(Title::from("Loading...").alignment(Alignment::Center))
+            .line_style(
+                Span::styled(HORIZONTAL, Style::new().fg(Color::Red)),
+                Span::styled(HORIZONTAL, Style::new().fg(Color::Gray)),
+            )
+            .progress(0.0);
     }
 }

--- a/src/components/list.rs
+++ b/src/components/list.rs
@@ -13,7 +13,7 @@ use tuirealm::ratatui::{
 };
 use tuirealm::{Frame, MockComponent, State, StateValue};
 
-use crate::utils;
+use crate::utils::{self, borrow_clone_line};
 
 // -- States
 
@@ -167,8 +167,8 @@ impl List {
         self
     }
 
-    pub fn highlighted_str<S: Into<String>>(mut self, s: S) -> Self {
-        self.attr(Attribute::HighlightedStr, AttrValue::String(s.into()));
+    pub fn highlighted_str<S: Into<LineStatic>>(mut self, s: S) -> Self {
+        self.attr(Attribute::HighlightedStr, AttrValue::TextLine(s.into()));
         self
     }
 
@@ -295,9 +295,9 @@ impl MockComponent for List {
             let hg_str = self
                 .props
                 .get_ref(Attribute::HighlightedStr)
-                .and_then(|x| x.as_string());
+                .and_then(|x| x.as_textline());
             if let Some(hg_str) = hg_str {
-                list = list.highlight_symbol(hg_str.as_str());
+                list = list.highlight_symbol(borrow_clone_line(hg_str));
             }
             if self.scrollable() {
                 let mut state: ListState = ListState::default();

--- a/src/components/list.rs
+++ b/src/components/list.rs
@@ -297,7 +297,7 @@ impl MockComponent for List {
                 .get_ref(Attribute::HighlightedStr)
                 .and_then(|x| x.as_string());
             if let Some(hg_str) = hg_str {
-                list = list.highlight_symbol(hg_str);
+                list = list.highlight_symbol(hg_str.as_str());
             }
             if self.scrollable() {
                 let mut state: ListState = ListState::default();

--- a/src/components/props.rs
+++ b/src/components/props.rs
@@ -20,6 +20,9 @@ pub const CANVAS_MARKER_DOT: isize = 1;
 pub const CANVAS_MARKER_BLOCK: isize = 2;
 pub const CANVAS_MARKER_BAR: isize = 3;
 pub const CANVAS_MARKER_HALF_BLOCK: isize = 4;
+pub const CANVAS_MARKER_QUADRANT: isize = 5;
+pub const CANVAS_MARKER_SEXTANT: isize = 6;
+pub const CANVAS_MARKER_OCTANT: isize = 7;
 
 // -- chart
 

--- a/src/components/props.rs
+++ b/src/components/props.rs
@@ -41,13 +41,6 @@ pub const INPUT_INVALID_STYLE: &str = "invalid-style";
 pub const INPUT_PLACEHOLDER: &str = "placeholder";
 pub const INPUT_PLACEHOLDER_STYLE: &str = "placeholder-style";
 
-// -- line gauge
-
-pub const LINE_GAUGE_STYLE_NORMAL: u8 = 0;
-pub const LINE_GAUGE_STYLE_DOUBLE: u8 = 1;
-pub const LINE_GAUGE_STYLE_ROUND: u8 = 2;
-pub const LINE_GAUGE_STYLE_THICK: u8 = 3;
-
 // -- table
 
 pub const TABLE_COLUMN_SPACING: &str = "col-spacing";

--- a/src/components/select.rs
+++ b/src/components/select.rs
@@ -5,8 +5,8 @@
 
 use tuirealm::command::{Cmd, CmdResult, Direction};
 use tuirealm::props::{
-    AttrValue, Attribute, BorderSides, Borders, Color, PropPayload, PropValue, Props, Style,
-    TextModifiers, Title,
+    AttrValue, Attribute, BorderSides, Borders, Color, LineStatic, PropPayload, PropValue, Props,
+    Style, TextModifiers, Title,
 };
 use tuirealm::ratatui::text::Line as Spans;
 use tuirealm::ratatui::{
@@ -14,6 +14,8 @@ use tuirealm::ratatui::{
     widgets::{List, ListItem, ListState, Paragraph},
 };
 use tuirealm::{Frame, MockComponent, State, StateValue};
+
+use crate::utils::borrow_clone_line;
 
 // -- states
 
@@ -140,8 +142,8 @@ impl Select {
         self
     }
 
-    pub fn highlighted_str<S: Into<String>>(mut self, s: S) -> Self {
-        self.attr(Attribute::HighlightedStr, AttrValue::String(s.into()));
+    pub fn highlighted_str<S: Into<LineStatic>>(mut self, s: S) -> Self {
+        self.attr(Attribute::HighlightedStr, AttrValue::TextLine(s.into()));
         self
     }
 
@@ -260,9 +262,9 @@ impl Select {
         let hg_str = self
             .props
             .get_ref(Attribute::HighlightedStr)
-            .and_then(|x| x.as_string());
+            .and_then(|x| x.as_textline());
         if let Some(hg_str) = hg_str {
-            list = list.highlight_symbol(hg_str.as_str());
+            list = list.highlight_symbol(borrow_clone_line(hg_str));
         }
         let mut state: ListState = ListState::default();
         state.select(Some(self.states.selected));

--- a/src/components/select.rs
+++ b/src/components/select.rs
@@ -262,7 +262,7 @@ impl Select {
             .get_ref(Attribute::HighlightedStr)
             .and_then(|x| x.as_string());
         if let Some(hg_str) = hg_str {
-            list = list.highlight_symbol(hg_str);
+            list = list.highlight_symbol(hg_str.as_str());
         }
         let mut state: ListState = ListState::default();
         state.select(Some(self.states.selected));

--- a/src/components/table.rs
+++ b/src/components/table.rs
@@ -6,8 +6,8 @@ use std::cmp::max;
 
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
 use tuirealm::props::{
-    AttrValue, Attribute, Borders, Color, PropPayload, PropValue, Props, Style, Table as PropTable,
-    TextModifiers, Title,
+    AttrValue, Attribute, Borders, Color, LineStatic, PropPayload, PropValue, Props, Style,
+    Table as PropTable, TextModifiers, Title,
 };
 use tuirealm::ratatui::{
     layout::{Constraint, Rect},
@@ -17,7 +17,7 @@ use tuirealm::ratatui::{
 use tuirealm::{Frame, MockComponent, State, StateValue};
 
 use super::props::TABLE_COLUMN_SPACING;
-use crate::utils;
+use crate::utils::{self, borrow_clone_line};
 
 // -- States
 
@@ -166,8 +166,8 @@ impl Table {
         self
     }
 
-    pub fn highlighted_str<S: Into<String>>(mut self, s: S) -> Self {
-        self.attr(Attribute::HighlightedStr, AttrValue::String(s.into()));
+    pub fn highlighted_str<S: Into<LineStatic>>(mut self, s: S) -> Self {
+        self.attr(Attribute::HighlightedStr, AttrValue::TextLine(s.into()));
         self
     }
 
@@ -379,9 +379,9 @@ impl MockComponent for Table {
             let hg_str = self
                 .props
                 .get_ref(Attribute::HighlightedStr)
-                .and_then(|x| x.as_string());
+                .and_then(|x| x.as_textline());
             if let Some(hg_str) = hg_str {
-                table = table.highlight_symbol(hg_str.as_str());
+                table = table.highlight_symbol(borrow_clone_line(hg_str));
             }
             // Col spacing
             if let Some(spacing) = self

--- a/src/components/textarea.rs
+++ b/src/components/textarea.rs
@@ -246,7 +246,7 @@ impl MockComponent for Textarea {
                 );
 
             if let Some(hg_str) = hg_str {
-                list = list.highlight_symbol(hg_str);
+                list = list.highlight_symbol(hg_str.as_str());
             }
             render.render_stateful_widget(list, area, &mut state);
         }

--- a/src/components/textarea.rs
+++ b/src/components/textarea.rs
@@ -8,15 +8,16 @@ extern crate unicode_width;
 
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
 use tuirealm::props::{
-    AttrValue, Attribute, Borders, Color, PropPayload, PropValue, Props, SpanStatic, Style,
-    TextModifiers, Title,
+    AttrValue, Attribute, Borders, Color, LineStatic, PropPayload, PropValue, Props, SpanStatic,
+    Style, TextModifiers, Title,
 };
 use tuirealm::ratatui::{
     layout::Rect,
     widgets::{List, ListItem, ListState},
 };
 use tuirealm::{Frame, MockComponent, State};
-use unicode_width::UnicodeWidthStr;
+
+use crate::utils::borrow_clone_line;
 
 // -- States
 
@@ -155,8 +156,8 @@ impl Textarea {
         self
     }
 
-    pub fn highlighted_str<S: Into<String>>(mut self, s: S) -> Self {
-        self.attr(Attribute::HighlightedStr, AttrValue::String(s.into()));
+    pub fn highlighted_str<S: Into<LineStatic>>(mut self, s: S) -> Self {
+        self.attr(Attribute::HighlightedStr, AttrValue::TextLine(s.into()));
         self
     }
 
@@ -177,7 +178,7 @@ impl MockComponent for Textarea {
             let hg_str = self
                 .props
                 .get_ref(Attribute::HighlightedStr)
-                .and_then(|x| x.as_string());
+                .and_then(|x| x.as_textline());
             // NOTE: wrap width is width of area minus 2 (block) minus width of highlighting string
             let wrap_width = (area.width as usize) - hg_str.as_ref().map_or(0, |x| x.width()) - 2;
             // TODO: refactor to use "Text"?
@@ -246,7 +247,7 @@ impl MockComponent for Textarea {
                 );
 
             if let Some(hg_str) = hg_str {
-                list = list.highlight_symbol(hg_str.as_str());
+                list = list.highlight_symbol(borrow_clone_line(hg_str));
             }
             render.render_stateful_widget(list, area, &mut state);
         }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -12,8 +12,7 @@ use tuirealm::props::{Borders, Title};
 // ext
 use tuirealm::ratatui::style::{Color, Style};
 use tuirealm::ratatui::text::{Line, Span, Text};
-use tuirealm::ratatui::widgets::Block;
-use tuirealm::ratatui::widgets::block::Position;
+use tuirealm::ratatui::widgets::{Block, TitlePosition};
 use unicode_width::UnicodeWidthStr;
 
 /// ### wrap_spans
@@ -90,8 +89,8 @@ pub fn get_block(
 
     if let Some(title) = title {
         block = match title.position {
-            Position::Top => block.title_top(borrow_clone_line(&title.content)),
-            Position::Bottom => block.title_bottom(borrow_clone_line(&title.content)),
+            TitlePosition::Top => block.title_top(borrow_clone_line(&title.content)),
+            TitlePosition::Bottom => block.title_bottom(borrow_clone_line(&title.content)),
         };
     }
 


### PR DESCRIPTION
# ISSUE _NUMBER_ - PULL_REQUEST_TITLE

~~Depends on #52~~

## Description

This PR applies changes necessary for the ratatui 0.30 (and resulting tuirealm(core)) changes.
Additionally does:
- due to ratatui 0.30 allowing individual customization of LineGauge Filled & Unfilled style & symbols, stdlib was changed to allow for that (resulting in removed isize properties)
- due to ratatui 0.30 allowing `Line` for highlight symbols, stdlib was changed from `String` to `LineStatic`
- correct the `Chart` `Marker` mappings
- add new `Chart` `Marker` mappings that are new in ratatui 0.30

## Type of change

Please select relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no new *C-bindings*
- [x] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit
