### PR TITLE
Fix documentation

### DIFF
--- a/src/components/bar_chart.rs
+++ b/src/components/bar_chart.rs
@@ -1,5 +1,3 @@
-//! ## BarChart
-//!
 //! A chart with bars
 
 use std::collections::LinkedList;
@@ -21,43 +19,33 @@ use super::props::{
 
 // -- states
 
-/// ### BarChartStates
-///
-/// Bar chart states
+/// The state that needs to be kept for the [`BarChart`] Component.
 #[derive(Default)]
 pub struct BarChartStates {
     pub cursor: usize,
 }
 
 impl BarChartStates {
-    /// ### move_cursor_left
-    ///
-    /// Move cursor to the left
+    /// Move cursor to the left.
     pub fn move_cursor_left(&mut self) {
         if self.cursor > 0 {
             self.cursor -= 1;
         }
     }
 
-    /// ### move_cursor_right
-    ///
-    /// Move cursor to the right
+    /// Move cursor to the right.
     pub fn move_cursor_right(&mut self, data_len: usize) {
         if data_len > 0 && self.cursor + 1 < data_len {
             self.cursor += 1;
         }
     }
 
-    /// ### reset_cursor
-    ///
-    /// Reset cursor to 0
+    /// Reset cursor to 0.
     pub fn reset_cursor(&mut self) {
         self.cursor = 0;
     }
 
-    /// ### cursor_at_end
-    ///
-    /// Move cursor to the end of the chart
+    /// Move cursor to the end of the chart.
     pub fn cursor_at_end(&mut self, data_len: usize) {
         if data_len > 0 {
             self.cursor = data_len - 1;
@@ -69,19 +57,17 @@ impl BarChartStates {
 
 // -- component
 
-/// ### BarChart
-///
 /// A component to display a chart with bars.
 /// The bar chart can work both in "active" and "disabled" mode.
 ///
-/// #### Disabled mode
+/// ## Disabled mode
 ///
 /// When in disabled mode, the chart won't be interactive, so you won't be able to move through data using keys.
-/// If you have more data than the maximum amount of bars that can be displayed, you'll have to update data to display the remaining entries
+/// If you have more data than the maximum amount of bars that can be displayed, you'll have to update data to display the remaining entries.
 ///
-/// #### Active mode
+/// ## Active mode
 ///
-/// While in active mode (default) you can put as many entries as you wish. You can move with arrows and END/HOME keys
+/// While in active mode (default) you can put as many entries as you wish. You can move with [`Cmd::Move`] or [`Cmd::GoTo`].
 #[derive(Default)]
 #[must_use]
 pub struct BarChart {

--- a/src/components/bar_chart.rs
+++ b/src/components/bar_chart.rs
@@ -3,7 +3,8 @@
 use std::collections::LinkedList;
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
 use tuirealm::props::{
-    AttrValue, Attribute, Borders, Color, PropPayload, PropValue, Props, Style, Title,
+    AttrValue, Attribute, Borders, Color, PropPayload, PropValue, Props, Style, TextModifiers,
+    Title,
 };
 use tuirealm::ratatui::{layout::Rect, widgets::BarChart as TuiBarChart};
 use tuirealm::{Frame, MockComponent, State};
@@ -86,6 +87,12 @@ impl BarChart {
     /// Set the main background color. This may get overwritten by individual text styles.
     pub fn background(mut self, bg: Color) -> Self {
         self.attr(Attribute::Background, AttrValue::Color(bg));
+        self
+    }
+
+    /// Set the main text modifiers. This may get overwritten by individual text styles.
+    pub fn modifiers(mut self, m: TextModifiers) -> Self {
+        self.attr(Attribute::TextProps, AttrValue::TextModifiers(m));
         self
     }
 

--- a/src/components/canvas.rs
+++ b/src/components/canvas.rs
@@ -2,7 +2,8 @@
 
 use tuirealm::command::{Cmd, CmdResult};
 use tuirealm::props::{
-    AttrValue, Attribute, Borders, Color, PropPayload, PropValue, Props, Shape, Style, Title,
+    AttrValue, Attribute, Borders, Color, PropPayload, PropValue, Props, Shape, Style,
+    TextModifiers, Title,
 };
 use tuirealm::ratatui::symbols::Marker;
 use tuirealm::ratatui::text::Line as Spans;
@@ -45,6 +46,12 @@ impl Canvas {
     /// Set the main background color. This may get overwritten by individual text styles.
     pub fn background(mut self, bg: Color) -> Self {
         self.attr(Attribute::Background, AttrValue::Color(bg));
+        self
+    }
+
+    /// Set the main text modifiers. This may get overwritten by individual text styles.
+    pub fn modifiers(mut self, m: TextModifiers) -> Self {
+        self.attr(Attribute::TextProps, AttrValue::TextModifiers(m));
         self
     }
 

--- a/src/components/canvas.rs
+++ b/src/components/canvas.rs
@@ -1,6 +1,4 @@
-//! ## Canvas
-//!
-//! A canvas where you can draw more complex figures
+//! A canvas where you can draw more complex figures.
 
 use tuirealm::command::{Cmd, CmdResult};
 use tuirealm::props::{
@@ -26,9 +24,7 @@ use super::props::{
 
 // -- Component
 
-/// ## Canvas
-///
-/// The Canvas widget may be used to draw more detailed figures using braille patterns (each cell can have a braille character in 8 different positions).
+/// The Canvas component may be used to draw more detailed figures using braille patterns (each cell can have a braille character in 8 different positions).
 #[derive(Default)]
 #[must_use]
 pub struct Canvas {
@@ -89,12 +85,12 @@ impl Canvas {
         self
     }
 
-    /// From <https://github.com/fdehau/tui-rs/issues/286>:
+    /// Those are used to define the viewport of the canvas.
+    /// Only the points whose coordinates are within the viewport are displayed.
+    /// When you render the canvas using Frame::render_widget, you give an area to draw the widget to (a Rect) and
+    /// the crate translates the floating point coordinates to those used by our internal terminal representation.
     ///
-    /// > Those are used to define the viewport of the canvas.
-    /// > Only the points whose coordinates are within the viewport are displayed.
-    /// > When you render the canvas using Frame::render_widget, you give an area to draw the widget to (a Rect) and
-    /// > the crate translates the floating point coordinates to those used by our internal terminal representation.
+    /// From <https://github.com/fdehau/tui-rs/issues/286>, also read [`Canvas::x_bounds`](TuiCanvas::x_bounds).
     pub fn x_bounds(mut self, bounds: (f64, f64)) -> Self {
         self.attr(
             Attribute::Custom(CANVAS_X_BOUNDS),
@@ -106,12 +102,12 @@ impl Canvas {
         self
     }
 
-    /// From <https://github.com/fdehau/tui-rs/issues/286>:
+    /// Those are used to define the viewport of the canvas.
+    /// Only the points whose coordinates are within the viewport are displayed.
+    /// When you render the canvas using Frame::render_widget, you give an area to draw the widget to (a Rect) and
+    /// the crate translates the floating point coordinates to those used by our internal terminal representation.
     ///
-    /// > Those are used to define the viewport of the canvas.
-    /// > Only the points whose coordinates are within the viewport are displayed.
-    /// > When you render the canvas using Frame::render_widget, you give an area to draw the widget to (a Rect) and
-    /// > the crate translates the floating point coordinates to those used by our internal terminal representation.
+    /// From <https://github.com/fdehau/tui-rs/issues/286>, also read [`Canvas::y_bounds`](TuiCanvas::y_bounds).
     pub fn y_bounds(mut self, bounds: (f64, f64)) -> Self {
         self.attr(
             Attribute::Custom(CANVAS_Y_BOUNDS),
@@ -123,7 +119,7 @@ impl Canvas {
         self
     }
 
-    /// Set marker to use to draw on canvas
+    /// Set which kind of [`Marker`] type should be used for a point.
     pub fn marker(mut self, marker: Marker) -> Self {
         self.attr(
             Attribute::Custom(CANVAS_MARKER),
@@ -167,7 +163,7 @@ impl Canvas {
         }
     }
 
-    /// Draw a shape into the canvas `Context`
+    /// Draw a shape into the canvas `Context`.
     fn draw_shape(ctx: &mut Context, shape: &Shape) {
         match shape {
             Shape::Label((x, y, label, color)) => {

--- a/src/components/chart/chart.rs
+++ b/src/components/chart/chart.rs
@@ -4,7 +4,8 @@ use std::any::Any;
 
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
 use tuirealm::props::{
-    AttrValue, Attribute, Borders, Color, PropPayload, PropValue, Props, Style, Title,
+    AttrValue, Attribute, Borders, Color, PropPayload, PropValue, Props, Style, TextModifiers,
+    Title,
 };
 use tuirealm::ratatui::text::Line;
 use tuirealm::ratatui::{
@@ -90,6 +91,12 @@ impl Chart {
     /// Set the main background color. This may get overwritten by individual text styles.
     pub fn background(mut self, bg: Color) -> Self {
         self.props.set(Attribute::Background, AttrValue::Color(bg));
+        self
+    }
+
+    /// Set the main text modifiers. This may get overwritten by individual text styles.
+    pub fn modifiers(mut self, m: TextModifiers) -> Self {
+        self.attr(Attribute::TextProps, AttrValue::TextModifiers(m));
         self
     }
 

--- a/src/components/chart/chart.rs
+++ b/src/components/chart/chart.rs
@@ -1,5 +1,3 @@
-//! ## Chart
-//!
 //! A component to plot one or more dataset in a cartesian coordinate system
 
 use std::any::Any;
@@ -24,9 +22,7 @@ use crate::props::{
     CHART_Y_STYLE, CHART_Y_TITLE,
 };
 
-/// ### ChartStates
-///
-/// chart states
+/// The state that needs to be kepts for the [`Chart`] component.
 #[derive(Default)]
 pub struct ChartStates {
     pub cursor: usize,
@@ -34,34 +30,26 @@ pub struct ChartStates {
 }
 
 impl ChartStates {
-    /// ### move_cursor_left
-    ///
-    /// Move cursor to the left
+    /// Move cursor to the left.
     pub fn move_cursor_left(&mut self) {
         if self.cursor > 0 {
             self.cursor -= 1;
         }
     }
 
-    /// ### move_cursor_right
-    ///
-    /// Move cursor to the right
+    /// Move cursor to the right.
     pub fn move_cursor_right(&mut self, data_len: usize) {
         if data_len > 0 && self.cursor + 1 < data_len {
             self.cursor += 1;
         }
     }
 
-    /// ### reset_cursor
-    ///
-    /// Reset cursor to 0
+    /// Reset cursor to 0.
     pub fn reset_cursor(&mut self) {
         self.cursor = 0;
     }
 
-    /// ### cursor_at_end
-    ///
-    /// Move cursor to the end of the chart
+    /// Move cursor to the end of the chart.
     pub fn cursor_at_end(&mut self, data_len: usize) {
         if data_len > 0 {
             self.cursor = data_len - 1;
@@ -73,19 +61,17 @@ impl ChartStates {
 
 // -- component
 
-/// ### Chart
-///
 /// A component to display a chart on a cartesian coordinate system.
 /// The chart can work both in "active" and "disabled" mode.
 ///
-/// #### Disabled mode
+/// ## Disabled mode
 ///
 /// When in disabled mode, the chart won't be interactive, so you won't be able to move through data using keys.
-/// If you have more data than the maximum amount of bars that can be displayed, you'll have to update data to display the remaining entries
+/// If you have more data than the maximum amount of bars that can be displayed, you'll have to update data to display the remaining entries.
 ///
-/// #### Active mode
+/// ## Active mode
 ///
-/// While in active mode (default) you can put as many entries as you wish. You can move with arrows and END/HOME keys
+/// While in active mode (default) you can put as many entries as you wish. You can move with [`Cmd::Move`] or [`Cmd::GoTo`].
 #[derive(Default)]
 #[must_use]
 pub struct Chart {
@@ -227,11 +213,13 @@ impl Chart {
         self
     }
 
+    /// Overwrite the data in this Chart, also applies all resets necessary.
     fn set_data(&mut self, data: Vec<ChartDataset>) {
         self.states.data = data;
         self.states.reset_cursor();
     }
 
+    /// Determine if the [`Attribute::Disabled`] is enabled.
     fn is_disabled(&self) -> bool {
         self.props
             .get_or(Attribute::Disabled, AttrValue::Flag(false))

--- a/src/components/chart/dataset.rs
+++ b/src/components/chart/dataset.rs
@@ -1,12 +1,10 @@
-//! ## Dataset
-//!
-//! `Dataset` is a wrapper for tui dataset
-
 use tuirealm::props::{LineStatic, Style};
 use tuirealm::ratatui::symbols::Marker;
 use tuirealm::ratatui::widgets::{Dataset as TuiDataset, GraphType};
 
-/// Dataset describes a set of data for a chart
+/// Dataset describes a set of data for a chart.
+///
+/// This mainly exists to map to ratatui's [`Dataset`](TuiDataset), which does not allow owned data.
 #[derive(Clone, Debug)]
 pub struct ChartDataset {
     pub name: LineStatic,
@@ -29,59 +27,63 @@ impl Default for ChartDataset {
 }
 
 impl ChartDataset {
-    /// Set name for dataset
+    /// Set a name for the dataset.
     pub fn name<S: Into<LineStatic>>(mut self, name: S) -> Self {
         self.name = name.into();
         self
     }
 
-    /// Set marker type for dataset
+    /// Set the [`Marker`] type for the dataset.
     pub fn marker(mut self, m: Marker) -> Self {
         self.marker = m;
         self
     }
 
-    /// Set graphtype for dataset
+    /// Set the [`GraphType`] for the dataset.
     pub fn graph_type(mut self, g: GraphType) -> Self {
         self.graph_type = g;
         self
     }
 
-    /// Set style for dataset
+    /// Set Style for the dataset.
+    ///
+    /// This style is used for the data points and the legenend (if not overwritten by the text's style).
+    ///
+    /// Read more in [`Dataset::style`](TuiDataset::style).
     pub fn style(mut self, s: Style) -> Self {
         self.style = s;
         self
     }
 
-    /// Set data for dataset; must be a vec of (f64, f64)
+    /// Set the data for this dataset.
     pub fn data(mut self, data: Vec<(f64, f64)>) -> Self {
         self.data = data;
         self
     }
 
-    /// Push a record to the back of dataset
+    /// Push a new point to the back of this dataset.
     pub fn push(&mut self, point: (f64, f64)) {
         self.data.push(point);
     }
 
-    /// Pop last element of dataset
+    /// Pop the last point from this dataset.
     pub fn pop(&mut self) {
         self.data.pop();
     }
 
-    /// Pop last element of dataset
+    /// Pop the first point in this dataset.
     pub fn pop_front(&mut self) {
         if !self.data.is_empty() {
             self.data.remove(0);
         }
     }
 
-    /// Get a reference to data
+    /// Get a reference to the data.
     pub fn get_data(&self) -> &[(f64, f64)] {
         &self.data
     }
 
-    /// Create [`TuiDataset`] from the current [`ChartDataset`].
+    /// Create ratatui [`Dataset`](TuiDataset) from the current [`ChartDataset`].
     ///
     /// Only elements from `start` are included.
     pub fn as_tuichart<'a>(&'a self, start: usize) -> TuiDataset<'a> {
@@ -103,12 +105,7 @@ impl PartialEq for ChartDataset {
 
 impl<'a> From<&'a ChartDataset> for TuiDataset<'a> {
     fn from(data: &'a ChartDataset) -> TuiDataset<'a> {
-        TuiDataset::default()
-            .name(data.name.clone())
-            .marker(data.marker)
-            .graph_type(data.graph_type)
-            .style(data.style)
-            .data(data.get_data())
+        data.as_tuichart(0)
     }
 }
 

--- a/src/components/checkbox.rs
+++ b/src/components/checkbox.rs
@@ -134,6 +134,12 @@ impl Checkbox {
         self
     }
 
+    /// Set the main text modifiers. This may get overwritten by individual text styles.
+    pub fn modifiers(mut self, m: TextModifiers) -> Self {
+        self.attr(Attribute::TextProps, AttrValue::TextModifiers(m));
+        self
+    }
+
     /// Set the main style. This may get overwritten by individual text styles.
     ///
     /// This option will overwrite any previous [`foreground`](Self::foreground), [`background`](Self::background) and [`modifiers`](Self::modifiers)!

--- a/src/components/checkbox.rs
+++ b/src/components/checkbox.rs
@@ -1,6 +1,4 @@
-//! ## Checkbox
-//!
-//! `Checkbox` component renders a checkbox group
+//! `Checkbox` component renders a checkbox group.
 
 /**
  * MIT License
@@ -38,20 +36,19 @@ use crate::prop_ext::CommonProps;
 
 // -- states
 
-/// ## CheckboxStates
-///
-/// CheckboxStates contains states for this component
+/// The state that needs to be kept for [`Checkbox`].
 #[derive(Default)]
 pub struct CheckboxStates {
-    pub choice: usize,         // Selected option
-    pub choices: Vec<String>,  // Available choices
-    pub selection: Vec<usize>, // Selected options
+    /// Current hover option.
+    pub choice: usize,
+    /// Available choices.
+    pub choices: Vec<String>,
+    /// Enabled options.
+    pub selection: Vec<usize>,
 }
 
 impl CheckboxStates {
-    /// ### next_choice
-    ///
-    /// Move choice index to next choice
+    /// Move choice index to next choice.
     pub fn next_choice(&mut self, rewind: bool) {
         if rewind && self.choice + 1 >= self.choices.len() {
             self.choice = 0;
@@ -60,9 +57,7 @@ impl CheckboxStates {
         }
     }
 
-    /// ### prev_choice
-    ///
-    /// Move choice index to previous choice
+    /// Move choice index to previous choice.
     pub fn prev_choice(&mut self, rewind: bool) {
         if rewind && self.choice == 0 && !self.choices.is_empty() {
             self.choice = self.choices.len() - 1;
@@ -71,9 +66,7 @@ impl CheckboxStates {
         }
     }
 
-    /// ### toggle
-    ///
-    /// Check or uncheck the option
+    /// Check or uncheck the option.
     pub fn toggle(&mut self) {
         let option = self.choice;
         if self.selection.contains(&option) {
@@ -84,25 +77,23 @@ impl CheckboxStates {
         }
     }
 
+    /// Select a specific option.
     pub fn select(&mut self, i: usize) {
         if i < self.choices.len() && !self.selection.contains(&i) {
             self.selection.push(i);
         }
     }
 
-    /// ### has
-    ///
-    /// Returns whether selection contains option
+    /// Determine if `options` is toggeled as selected.
     #[must_use]
     pub fn has(&self, option: usize) -> bool {
         self.selection.contains(&option)
     }
 
-    /// ### set_choices
+    /// Overwrite the choices available with new ones.
     ///
-    /// Set CheckboxStates choices from a vector of str
     /// In addition resets current selection and keep index if possible or set it to the first value
-    /// available
+    /// available.
     pub fn set_choices(&mut self, choices: impl Into<Vec<String>>) {
         self.choices = choices.into();
         // Clear selection
@@ -119,9 +110,9 @@ impl CheckboxStates {
 
 // -- component
 
-/// ## Checkbox
+/// The checkbox component is a multi-choice selector.
 ///
-/// Checkbox component represents a group of tabs to select from
+/// Use [`Radio`](crate::Radio) if a single-choice selector is wanted.
 #[derive(Default)]
 #[must_use]
 pub struct Checkbox {

--- a/src/components/container.rs
+++ b/src/components/container.rs
@@ -1,10 +1,4 @@
-//! ## Container
-//!
 //! `Container` represents an empty container where you can put other components into it.
-//! It will render components based on how you defined the layout.
-//! The way it updates properties is usually assigning the attributes to all the children components, but
-//! when defining the component you can override these behaviours implementing `attr()` by yourself.
-//! By default it will forward `Commands' to all the children and will return a `CmdResult::Batch` with all the results.
 
 use tuirealm::command::{Cmd, CmdResult};
 use tuirealm::props::{AttrValue, Attribute, Borders, Color, Layout, Props, Style, Title};
@@ -15,9 +9,12 @@ use crate::prop_ext::CommonProps;
 
 // -- Component
 
-/// ## Container
+/// `Container` represents an empty container where you can put other components into it.
 ///
-/// represents a read-only text component without any container.
+/// It will render components based on how you defined the layout.
+/// The way it updates properties is usually by assigning the attributes to all the children components, but
+/// when defining the component you can override these behaviours by implementing `attr()` yourself and directly accessing `children`'s `attr()`.
+/// By default it will forward `Commands' to all the children and will return a `CmdResult::Batch` with all the results.
 #[must_use]
 pub struct Container {
     common: CommonProps,

--- a/src/components/container.rs
+++ b/src/components/container.rs
@@ -1,7 +1,9 @@
 //! `Container` represents an empty container where you can put other components into it.
 
 use tuirealm::command::{Cmd, CmdResult};
-use tuirealm::props::{AttrValue, Attribute, Borders, Color, Layout, Props, Style, Title};
+use tuirealm::props::{
+    AttrValue, Attribute, Borders, Color, Layout, Props, Style, TextModifiers, Title,
+};
 use tuirealm::ratatui::layout::Rect;
 use tuirealm::{Frame, MockComponent, State};
 
@@ -46,6 +48,12 @@ impl Container {
     /// Set the main background color. This may get overwritten by individual text styles.
     pub fn background(mut self, bg: Color) -> Self {
         self.attr(Attribute::Background, AttrValue::Color(bg));
+        self
+    }
+
+    /// Set the main text modifiers. This may get overwritten by individual text styles.
+    pub fn modifiers(mut self, m: TextModifiers) -> Self {
+        self.attr(Attribute::TextProps, AttrValue::TextModifiers(m));
         self
     }
 

--- a/src/components/input.rs
+++ b/src/components/input.rs
@@ -1,5 +1,3 @@
-//! ## Input
-//!
 //! `Input` represents a read-write input field. This component supports different input types, input length
 //! and handles input events related to cursor position, backspace, canc, ...
 
@@ -18,6 +16,7 @@ use tuirealm::{Frame, MockComponent, State, StateValue};
 /// The number of characters [`InputStates::display_offset`] will keep in view in a single direction.
 const PREVIEW_DISTANCE: usize = 2;
 
+/// The state that needs to be kept for the [`Input`] component.
 #[derive(Default, Debug)]
 pub struct InputStates {
     /// The current input text
@@ -33,9 +32,7 @@ pub struct InputStates {
 }
 
 impl InputStates {
-    /// ### append
-    ///
-    /// Append, if possible according to input type, the character to the input vec
+    /// Append a character, if possible according to input type.
     pub fn append(&mut self, ch: char, itype: &InputType, max_len: Option<usize>) {
         // Check if max length has been reached
         if self.input.len() < max_len.unwrap_or(usize::MAX) {
@@ -47,9 +44,7 @@ impl InputStates {
         }
     }
 
-    /// ### backspace
-    ///
-    /// Delete element at cursor -1; then decrement cursor by 1
+    /// Delete the element at `cursor - 1`, then decrement cursor by 1.
     pub fn backspace(&mut self) {
         if self.cursor > 0 && !self.input.is_empty() {
             self.input.remove(self.cursor - 1);
@@ -62,18 +57,14 @@ impl InputStates {
         }
     }
 
-    /// ### delete
-    ///
-    /// Delete element at cursor
+    /// Delete element at cursor position.
     pub fn delete(&mut self) {
         if self.cursor < self.input.len() {
             self.input.remove(self.cursor);
         }
     }
 
-    /// ### incr_cursor
-    ///
-    /// Increment cursor value by one if possible
+    /// Increment cursor by one if possible. (also known as moving RIGHT)
     pub fn incr_cursor(&mut self) {
         if self.cursor < self.input.len() {
             self.cursor += 1;
@@ -95,27 +86,7 @@ impl InputStates {
         }
     }
 
-    /// ### cursoro_at_begin
-    ///
-    /// Place cursor at the begin of the input
-    pub fn cursor_at_begin(&mut self) {
-        self.cursor = 0;
-        self.display_offset = 0;
-    }
-
-    /// ### cursor_at_end
-    ///
-    /// Place cursor at the end of the input
-    pub fn cursor_at_end(&mut self) {
-        self.cursor = self.input.len();
-        self.display_offset = self.input.len().saturating_sub(
-            usize::from(self.last_width.unwrap_or_default()).saturating_sub(PREVIEW_DISTANCE),
-        );
-    }
-
-    /// ### decr_cursor
-    ///
-    /// Decrement cursor value by one if possible
+    /// Decrement cursor value by one if possible. (also known as moving LEFT)
     pub fn decr_cursor(&mut self) {
         if self.cursor > 0 {
             self.cursor -= 1;
@@ -126,8 +97,20 @@ impl InputStates {
         }
     }
 
-    /// ### update_width
-    ///
+    /// Move the cursor to the beginning of the input.
+    pub fn cursor_at_begin(&mut self) {
+        self.cursor = 0;
+        self.display_offset = 0;
+    }
+
+    /// Move the cursor the the end of the input.
+    pub fn cursor_at_end(&mut self) {
+        self.cursor = self.input.len();
+        self.display_offset = self.input.len().saturating_sub(
+            usize::from(self.last_width.unwrap_or_default()).saturating_sub(PREVIEW_DISTANCE),
+        );
+    }
+
     /// Update the last width used to display [`InputStates::input`].
     ///
     /// This is necessary to update [`InputStates::display_offset`] correctly and keep it
@@ -154,17 +137,15 @@ impl InputStates {
         }
     }
 
-    /// ### render_value
-    ///
-    /// Get value as string to render
+    /// Get the full text to render in the input, according to the [`InputType`].
     #[must_use]
     pub fn render_value(&self, itype: InputType) -> String {
         self.render_value_chars(itype).iter().collect::<String>()
     }
 
-    /// ### render_value_offset
+    /// Get the partial text to render, according to the [`InputType`].
     ///
-    /// Get value as a string to render, with the [`InputStates::display_offset`] already skipped.
+    /// Unlike [`InputStates::render_value`], this will only collect the actually displayed text in the returned String.
     #[must_use]
     pub fn render_value_offset(&self, itype: InputType) -> String {
         self.render_value_chars(itype)
@@ -173,11 +154,12 @@ impl InputStates {
             .collect()
     }
 
-    /// ### render_value_chars
+    /// Get the characters to render, according to [`InputType`].
     ///
-    /// Render value as a vec of chars
+    /// It is recommended to use [`render_value`](Self::render_value) or [`render_value_offset`](Self::render_value_offset) over this function.
     #[must_use]
     pub fn render_value_chars(&self, itype: InputType) -> Vec<char> {
+        // TODO: can we return a iterator or something to prevent this intermediary Vec?
         match itype {
             InputType::Password(ch) | InputType::CustomPassword(ch, _, _) => {
                 (0..self.input.len()).map(|_| ch).collect()
@@ -186,9 +168,7 @@ impl InputStates {
         }
     }
 
-    /// ### get_value
-    ///
-    /// Get value as string
+    /// Get the current input as a String in full, without any [`InputType`] modifications.
     #[must_use]
     pub fn get_value(&self) -> String {
         self.input.iter().collect()
@@ -197,9 +177,8 @@ impl InputStates {
 
 // -- Component
 
-/// ## Input
-///
-/// Input list component
+/// `Input` represents a read-write input field. This component supports different input types, input length
+/// and handles input events related to cursor position, backspace, canc, ...
 #[derive(Default)]
 #[must_use]
 pub struct Input {
@@ -303,9 +282,7 @@ impl Input {
             .unwrap_input_type()
     }
 
-    /// ### is_valid
-    ///
-    /// Checks whether current input is valid
+    /// Checks whether current input is valid according to the set [`InputType`].
     fn is_valid(&self) -> bool {
         let value = self.states.get_value();
         self.get_input_type().validate(value.as_str())

--- a/src/components/line_gauge.rs
+++ b/src/components/line_gauge.rs
@@ -1,7 +1,3 @@
-//! ## LineGauge
-//!
-//! `LineGauge` is a line gauge
-
 use tuirealm::command::{Cmd, CmdResult};
 use tuirealm::props::{
     AttrValue, Attribute, Borders, Color, PropPayload, PropValue, Props, SpanStatic, Style,
@@ -15,9 +11,11 @@ use crate::prop_ext::CommonProps;
 
 // -- Component
 
-/// ## LineGauge
+/// `LineGauge`, also known as progress bars, provides a component which shows a line which is some percent filled.
 ///
-/// provides a component which shows the progress. It is possible to set the style for the progress bar and the text shown above it.
+/// It is possible to set the style for the progress bar and the text shown above it.
+///
+/// Read more in [`LineGauge`](TuiLineGauge).
 #[derive(Default)]
 #[must_use]
 pub struct LineGauge {

--- a/src/components/list.rs
+++ b/src/components/list.rs
@@ -1,6 +1,4 @@
-//! ## List
-//!
-//! `List` represents a read-only textual list component which can be scrollable through arrows or inactive
+//! `List` represents a read-only textual list component which can be scrollable through arrows or inactive.
 
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
 use tuirealm::props::{
@@ -18,23 +16,22 @@ use crate::utils::{self, borrow_clone_line};
 
 // -- States
 
+/// The state that needs to be kept for the [`List`] componennt:
 #[derive(Default)]
 pub struct ListStates {
-    pub list_index: usize, // Index of selected item in list
-    pub list_len: usize,   // Lines in text area
+    /// Index of selected item in list
+    pub list_index: usize,
+    /// Lines in text area
+    pub list_len: usize,
 }
 
 impl ListStates {
-    /// ### set_list_len
-    ///
-    /// Set list length
+    /// Set the list length.
     pub fn set_list_len(&mut self, len: usize) {
         self.list_len = len;
     }
 
-    /// ### incr_list_index
-    ///
-    /// Incremenet list index
+    /// Incremenet the list index.
     pub fn incr_list_index(&mut self, rewind: bool) {
         // Check if index is at last element
         if self.list_index + 1 < self.list_len {
@@ -44,9 +41,7 @@ impl ListStates {
         }
     }
 
-    /// ### decr_list_index
-    ///
-    /// Decrement list index
+    /// Decrement the list index.
     pub fn decr_list_index(&mut self, rewind: bool) {
         // Check if index is bigger than 0
         if self.list_index > 0 {
@@ -56,9 +51,7 @@ impl ListStates {
         }
     }
 
-    /// ### fix_list_index
-    ///
-    /// Keep index if possible, otherwise set to lenght - 1
+    /// Keep index if possible, otherwise set to `lenght - 1`.
     pub fn fix_list_index(&mut self) {
         if self.list_index >= self.list_len && self.list_len > 0 {
             self.list_index = self.list_len - 1;
@@ -67,16 +60,12 @@ impl ListStates {
         }
     }
 
-    /// ### list_index_at_first
-    ///
-    /// Set list index to the first item in the list
+    /// Set the list index to the first item in the list.
     pub fn list_index_at_first(&mut self) {
         self.list_index = 0;
     }
 
-    /// ### list_index_at_last
-    ///
-    /// Set list index at the last item of the list
+    /// Set the list index at the last item of the list.
     pub fn list_index_at_last(&mut self) {
         if self.list_len > 0 {
             self.list_index = self.list_len - 1;
@@ -85,9 +74,7 @@ impl ListStates {
         }
     }
 
-    /// ### calc_max_step_ahead
-    ///
-    /// Calculate the max step ahead to scroll list
+    /// Calculate the max step ahead to scroll the list.
     #[must_use]
     pub fn calc_max_step_ahead(&self, max: usize) -> usize {
         let remaining: usize = match self.list_len {
@@ -97,9 +84,7 @@ impl ListStates {
         if remaining > max { max } else { remaining }
     }
 
-    /// ### calc_max_step_ahead
-    ///
-    /// Calculate the max step ahead to scroll list
+    /// Calculate the max step ahead to scroll the list.
     #[must_use]
     pub fn calc_max_step_behind(&self, max: usize) -> usize {
         if self.list_index > max {
@@ -112,9 +97,7 @@ impl ListStates {
 
 // -- Component
 
-/// ## List
-///
-/// represents a read-only text component without any container.
+/// `List` represents a read-only textual list component which can be scrollable through arrows or inactive.
 #[derive(Default)]
 #[must_use]
 pub struct List {

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -1,6 +1,4 @@
-//! ## Components
-//!
-//! `Components` provides a "standard" library of components.
+//! All components and their extra properties and state.
 
 // Modules
 mod bar_chart;

--- a/src/components/progress_bar.rs
+++ b/src/components/progress_bar.rs
@@ -1,5 +1,3 @@
-//! ## ProgressBar
-//!
 //! `ProgressBar` provides a component which shows the progress. It is possible to set the style for the progress bar and the text shown above it.
 
 use tuirealm::command::{Cmd, CmdResult};
@@ -14,9 +12,9 @@ use crate::prop_ext::CommonProps;
 
 // -- Component
 
-/// ## ProgressBar
-///
-/// provides a component which shows the progress. It is possible to set the style for the progress bar and the text shown above it.
+// TODO: we should remove this component in favor of just "LineGauge", as the implementation and inner workings are literally the same.
+
+/// `ProgressBar` provides a component which shows the progress. It is possible to set the style for the progress bar and the text shown above it.
 #[derive(Default)]
 #[must_use]
 pub struct ProgressBar {

--- a/src/components/props.rs
+++ b/src/components/props.rs
@@ -1,6 +1,4 @@
-//! # Props
-//!
-//! This module exposes components props name
+//! Custom properties for stdlib components.
 
 // -- bar-chart
 

--- a/src/components/radio.rs
+++ b/src/components/radio.rs
@@ -113,6 +113,12 @@ impl Radio {
         self
     }
 
+    /// Set the main text modifiers. This may get overwritten by individual text styles.
+    pub fn modifiers(mut self, m: TextModifiers) -> Self {
+        self.attr(Attribute::TextProps, AttrValue::TextModifiers(m));
+        self
+    }
+
     /// Set the main style. This may get overwritten by individual text styles.
     ///
     /// This option will overwrite any previous [`foreground`](Self::foreground), [`background`](Self::background) and [`modifiers`](Self::modifiers)!

--- a/src/components/radio.rs
+++ b/src/components/radio.rs
@@ -1,6 +1,4 @@
-//! ## Radio
-//!
-//! `Radio` component renders a radio group
+//! `Radio` component renders a radio group.
 
 /**
  * MIT License
@@ -38,18 +36,16 @@ use crate::prop_ext::CommonProps;
 
 // -- states
 
-/// ## RadioStates
-///
-/// RadioStates contains states for this component
+/// The state that needs to be kept for the [`Radio`] component.
 #[derive(Default)]
 pub struct RadioStates {
-    pub choice: usize,        // Selected option
-    pub choices: Vec<String>, // Available choices
+    /// Selected option.
+    pub choice: usize,
+    /// Available choices.
+    pub choices: Vec<String>,
 }
 
 impl RadioStates {
-    /// ### next_choice
-    ///
     /// Move choice index to next choice
     pub fn next_choice(&mut self, rewind: bool) {
         if rewind && self.choice + 1 >= self.choices.len() {
@@ -59,9 +55,7 @@ impl RadioStates {
         }
     }
 
-    /// ### prev_choice
-    ///
-    /// Move choice index to previous choice
+    /// Move choice index to previous choice.
     pub fn prev_choice(&mut self, rewind: bool) {
         if rewind && self.choice == 0 && !self.choices.is_empty() {
             self.choice = self.choices.len() - 1;
@@ -70,11 +64,10 @@ impl RadioStates {
         }
     }
 
-    /// ### set_choices
+    /// Overwrite the choices available with new ones.
     ///
-    /// Set RadioStates choices from a vector of text spans
     /// In addition resets current selection and keep index if possible or set it to the first value
-    /// available
+    /// available.
     pub fn set_choices(&mut self, choices: impl Into<Vec<String>>) {
         self.choices = choices.into();
         // Keep index if possible
@@ -86,6 +79,7 @@ impl RadioStates {
         }
     }
 
+    /// Select a specific choice.
     pub fn select(&mut self, i: usize) {
         if i < self.choices.len() {
             self.choice = i;
@@ -95,9 +89,9 @@ impl RadioStates {
 
 // -- component
 
-/// ## Radio
+/// The radio component is a single-choice selector.
 ///
-/// Radio component represents a group of tabs to select from
+/// Use [`Checkbox`](crate::Checkbox) if a multi-choice selector is wanted.
 #[derive(Default)]
 #[must_use]
 pub struct Radio {

--- a/src/components/select.rs
+++ b/src/components/select.rs
@@ -1,7 +1,5 @@
-//! ## Select
-//!
 //! `Select` represents a select field, like in HTML. The size for the component must be 3 (border + selected) + the quantity of rows
-//! you want to display other options when opened (at least 3)
+//! you want to display other options when opened (at least 3).
 
 use tuirealm::command::{Cmd, CmdResult, Direction};
 use tuirealm::props::{
@@ -20,9 +18,7 @@ use crate::utils::borrow_clone_line;
 
 // -- states
 
-/// ## SelectStates
-///
-/// Component states
+/// The states that need to be kept for the [`Select`] component.
 #[derive(Default)]
 pub struct SelectStates {
     /// Available choices
@@ -35,9 +31,7 @@ pub struct SelectStates {
 }
 
 impl SelectStates {
-    /// ### next_choice
-    ///
-    /// Move choice index to next choice
+    /// Move choice index to next choice.
     pub fn next_choice(&mut self, rewind: bool) {
         if self.tab_open {
             if rewind && self.selected + 1 >= self.choices.len() {
@@ -48,9 +42,7 @@ impl SelectStates {
         }
     }
 
-    /// ### prev_choice
-    ///
-    /// Move choice index to previous choice
+    /// Move choice index to previous choice.
     pub fn prev_choice(&mut self, rewind: bool) {
         if self.tab_open {
             if rewind && self.selected == 0 && !self.choices.is_empty() {
@@ -61,11 +53,10 @@ impl SelectStates {
         }
     }
 
-    /// ### set_choices
+    /// Overwrite the choices available with new ones.
     ///
-    /// Set SelectStates choices from a vector of str
     /// In addition resets current selection and keep index if possible or set it to the first value
-    /// available
+    /// available.
     pub fn set_choices(&mut self, choices: impl Into<Vec<String>>) {
         self.choices = choices.into();
         // Keep index if possible
@@ -83,30 +74,24 @@ impl SelectStates {
         }
     }
 
-    /// ### close_tab
-    ///
-    /// Close tab
+    /// Close tab.
     pub fn close_tab(&mut self) {
         self.tab_open = false;
     }
 
-    /// ### open_tab
-    ///
-    /// Open tab
+    /// Open tab.
     pub fn open_tab(&mut self) {
         self.previously_selected = self.selected;
         self.tab_open = true;
     }
 
-    /// Cancel tab open
+    /// Cancel tab open.
     pub fn cancel_tab(&mut self) {
         self.close_tab();
         self.selected = self.previously_selected;
     }
 
-    /// ### is_tab_open
-    ///
-    /// Returns whether the tab is open
+    /// Returns whether the tab is open.
     #[must_use]
     pub fn is_tab_open(&self) -> bool {
         self.tab_open
@@ -115,6 +100,11 @@ impl SelectStates {
 
 // -- component
 
+/// `Select` represents a select field, like in HTML. The size for the component must be 3 (border + selected) + the quantity of rows
+/// you want to display other options when opened (at least 3).
+///
+/// Similar to [`Radio`](crate::Radio), [`Select`] is a single-choice selector, but the difference is that it does not show the selector
+/// unless the "Tab" is open, and only shows the currently selected choice.
 #[derive(Default)]
 #[must_use]
 pub struct Select {

--- a/src/components/select.rs
+++ b/src/components/select.rs
@@ -126,6 +126,12 @@ impl Select {
         self
     }
 
+    /// Set the main text modifiers. This may get overwritten by individual text styles.
+    pub fn modifiers(mut self, m: TextModifiers) -> Self {
+        self.attr(Attribute::TextProps, AttrValue::TextModifiers(m));
+        self
+    }
+
     /// Set the main style. This may get overwritten by individual text styles.
     ///
     /// This option will overwrite any previous [`foreground`](Self::foreground), [`background`](Self::background) and [`modifiers`](Self::modifiers)!

--- a/src/components/sparkline.rs
+++ b/src/components/sparkline.rs
@@ -1,6 +1,4 @@
-//! ## Sparkline
-//!
-//! A sparkline over more lines
+//! A sparkline over more lines.
 
 use tuirealm::command::{Cmd, CmdResult};
 use tuirealm::props::{
@@ -13,9 +11,11 @@ use crate::prop_ext::CommonProps;
 
 // -- component
 
-/// ## Sparkline
+/// A sparkline over more lines.
 ///
-/// A sparkline over more lines
+/// A sparkline can be interpreted as a dense Vertical Bar Chart, without labels for each line.
+///
+/// This can be used for audio-level visualization or a type of history graph (like bandwidth, cpu usage, etc).
 #[derive(Default)]
 #[must_use]
 pub struct Sparkline {

--- a/src/components/spinner.rs
+++ b/src/components/spinner.rs
@@ -1,5 +1,3 @@
-//! ## Spinner
-//!
 //! A loading spinner. You can provide the "spinning sequence". At each `view()` call, the sequence step is increased
 
 use tuirealm::command::{Cmd, CmdResult};
@@ -11,6 +9,7 @@ use crate::prop_ext::CommonProps;
 
 // -- states
 
+/// The state that has to be kept for the [`Spinner`] component.
 #[derive(Default)]
 pub struct SpinnerStates {
     pub sequence: Vec<char>,
@@ -18,17 +17,13 @@ pub struct SpinnerStates {
 }
 
 impl SpinnerStates {
-    /// ### reset
-    ///
-    /// Re initialize sequence
+    /// Set a new sequence of characters and reset the stepping to 0.
     pub fn reset(&mut self, sequence: &str) {
         self.sequence = sequence.chars().collect();
         self.step = 0;
     }
 
-    /// ### step
-    ///
-    /// Get current step char and increments step
+    /// Get the current step's characters in the sequence, and increment the stepping.
     pub fn step(&mut self) -> char {
         let ch = self.sequence.get(self.step).copied().unwrap_or(' ');
         // Incr step
@@ -40,7 +35,7 @@ impl SpinnerStates {
         ch
     }
 
-    /// Get the current char to display
+    /// Get the current character to display.
     ///
     /// Unlike [`step`](Self::step), this function does not increment the step.
     pub fn current_step(&self) -> char {
@@ -50,9 +45,7 @@ impl SpinnerStates {
 
 // -- Component
 
-/// ## Spinner
-///
-/// A textual spinner which step changes at each `view()` call
+/// A textual spinner which step changes at each `view()` call (if `manual_step` is disabled).
 #[must_use]
 pub struct Spinner {
     common: CommonProps,

--- a/src/components/states.rs
+++ b/src/components/states.rs
@@ -1,6 +1,4 @@
-//! # States
-//!
-//! This module exposes component states
+//! This module exposes all `*State` structs for all components.
 
 pub use super::{
     bar_chart::BarChartStates, chart::ChartStates, checkbox::CheckboxStates, input::InputStates,

--- a/src/components/table.rs
+++ b/src/components/table.rs
@@ -1,6 +1,4 @@
-//! ## Table
-//!
-//! `Table` represents a read-only textual table component which can be scrollable through arrows or inactive
+//! `Table` represents a read-only textual table component which can be scrollable through arrows or inactive.
 
 use std::cmp::max;
 
@@ -22,23 +20,22 @@ use crate::utils::{self, borrow_clone_line};
 
 // -- States
 
+/// The state that has to be kept for the [`Table`] component.
 #[derive(Default)]
 pub struct TableStates {
-    pub list_index: usize, // Index of selected item in textarea
-    pub list_len: usize,   // Lines in text area
+    /// Index of selected item in textarea
+    pub list_index: usize,
+    /// Lines in text area
+    pub list_len: usize,
 }
 
 impl TableStates {
-    /// ### set_list_len
-    ///
-    /// Set list length
+    /// Set list length.
     pub fn set_list_len(&mut self, len: usize) {
         self.list_len = len;
     }
 
-    /// ### incr_list_index
-    ///
-    /// Incremenet list index
+    /// Incremenet list index.
     pub fn incr_list_index(&mut self, rewind: bool) {
         // Check if index is at last element
         if self.list_index + 1 < self.list_len {
@@ -48,9 +45,7 @@ impl TableStates {
         }
     }
 
-    /// ### decr_list_index
-    ///
-    /// Decrement list index
+    /// Decrement list index.
     pub fn decr_list_index(&mut self, rewind: bool) {
         // Check if index is bigger than 0
         if self.list_index > 0 {
@@ -60,9 +55,7 @@ impl TableStates {
         }
     }
 
-    /// ### fix_list_index
-    ///
-    /// Keep index if possible, otherwise set to lenght - 1
+    /// Keep index if possible, otherwise set to `lenght - 1`.
     pub fn fix_list_index(&mut self) {
         if self.list_index >= self.list_len && self.list_len > 0 {
             self.list_index = self.list_len - 1;
@@ -71,16 +64,12 @@ impl TableStates {
         }
     }
 
-    /// ### list_index_at_first
-    ///
-    /// Set list index to the first item in the list
+    /// Set list index to the first item in the list.
     pub fn list_index_at_first(&mut self) {
         self.list_index = 0;
     }
 
-    /// ### list_index_at_last
-    ///
-    /// Set list index at the last item of the list
+    /// Set list index at the last item of the list.
     pub fn list_index_at_last(&mut self) {
         if self.list_len > 0 {
             self.list_index = self.list_len - 1;
@@ -89,9 +78,7 @@ impl TableStates {
         }
     }
 
-    /// ### calc_max_step_ahead
-    ///
-    /// Calculate the max step ahead to scroll list
+    /// Calculate the max step ahead to scroll list.
     #[must_use]
     pub fn calc_max_step_ahead(&self, max: usize) -> usize {
         let remaining: usize = match self.list_len {
@@ -101,9 +88,7 @@ impl TableStates {
         if remaining > max { max } else { remaining }
     }
 
-    /// ### calc_max_step_ahead
-    ///
-    /// Calculate the max step ahead to scroll list
+    /// Calculate the max step ahead to scroll list.
     #[must_use]
     pub fn calc_max_step_behind(&self, max: usize) -> usize {
         if self.list_index > max {
@@ -116,9 +101,7 @@ impl TableStates {
 
 // -- Component
 
-/// ## Table
-///
-/// represents a read-only text component without any container.
+/// `Table` represents a read-only textual table component which can be scrollable through arrows or inactive.
 #[derive(Default)]
 #[must_use]
 pub struct Table {

--- a/src/components/textarea.rs
+++ b/src/components/textarea.rs
@@ -14,24 +14,23 @@ use crate::utils::borrow_clone_line;
 
 // -- States
 
+/// The state that has to be kept for the [`Textarea`] component.
 #[derive(Default)]
 pub struct TextareaStates {
-    pub list_index: usize, // Index of selected item in textarea
-    pub list_len: usize,   // Lines in text area
+    /// Index of selected item in textarea
+    pub list_index: usize,
+    /// Lines in text area
+    pub list_len: usize,
 }
 
 impl TextareaStates {
-    /// ### set_list_len
-    ///
-    /// Set list length and fix list index
+    /// Set list length and fix list index.
     pub fn set_list_len(&mut self, len: usize) {
         self.list_len = len;
         self.fix_list_index();
     }
 
-    /// ### incr_list_index
-    ///
-    /// Incremenet list index
+    /// Incremenet list index.
     pub fn incr_list_index(&mut self) {
         // Check if index is at last element
         if self.list_index + 1 < self.list_len {
@@ -39,9 +38,7 @@ impl TextareaStates {
         }
     }
 
-    /// ### decr_list_index
-    ///
-    /// Decrement list index
+    /// Decrement list index.
     pub fn decr_list_index(&mut self) {
         // Check if index is bigger than 0
         if self.list_index > 0 {
@@ -49,9 +46,7 @@ impl TextareaStates {
         }
     }
 
-    /// ### fix_list_index
-    ///
-    /// Keep index if possible, otherwise set to lenght - 1
+    /// Keep index if possible, otherwise set to `lenght - 1`.
     pub fn fix_list_index(&mut self) {
         if self.list_index >= self.list_len && self.list_len > 0 {
             self.list_index = self.list_len - 1;
@@ -60,16 +55,12 @@ impl TextareaStates {
         }
     }
 
-    /// ### list_index_at_first
-    ///
-    /// Set list index to the first item in the list
+    /// Set list index to the first item in the list.
     pub fn list_index_at_first(&mut self) {
         self.list_index = 0;
     }
 
-    /// ### list_index_at_last
-    ///
-    /// Set list index at the last item of the list
+    /// Set list index at the last item of the list.
     pub fn list_index_at_last(&mut self) {
         if self.list_len > 0 {
             self.list_index = self.list_len - 1;
@@ -78,9 +69,7 @@ impl TextareaStates {
         }
     }
 
-    /// ### calc_max_step_ahead
-    ///
-    /// Calculate the max step ahead to scroll list
+    /// Calculate the max step ahead to scroll list.
     fn calc_max_step_ahead(&self, max: usize) -> usize {
         let remaining: usize = match self.list_len {
             0 => 0,
@@ -89,9 +78,7 @@ impl TextareaStates {
         if remaining > max { max } else { remaining }
     }
 
-    /// ### calc_max_step_ahead
-    ///
-    /// Calculate the max step ahead to scroll list
+    /// Calculate the max step ahead to scroll list.
     fn calc_max_step_behind(&self, max: usize) -> usize {
         if self.list_index > max {
             max

--- a/src/prop_ext.rs
+++ b/src/prop_ext.rs
@@ -1,3 +1,5 @@
+//! Extra extensions to handle Properties.
+
 use tuirealm::{
     AttrValue, Attribute,
     props::{Borders, Style, Title},

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,3 @@
-//! ## Utils
-//!
 //! Utilities functions to work with components
 
 use std::borrow::Cow;
@@ -10,8 +8,6 @@ use tuirealm::ratatui::text::{Line, Span, Text};
 use tuirealm::ratatui::widgets::{Block, TitlePosition};
 use unicode_width::UnicodeWidthStr;
 
-/// ### wrap_spans
-///
 /// Given a vector of [`Span`]s, it creates a list of `Spans` which mustn't exceed the provided width parameter.
 /// Each [`Line`] in the returned `Vec` is a line in the text.
 #[must_use]
@@ -62,10 +58,9 @@ pub fn wrap_spans<'a, 'b: 'a>(spans: &[&'b Span<'a>], width: usize) -> Vec<Line<
     res
 }
 
-/// ### get_block
+/// Construct a [`Block`] widget from the given properties.
 ///
-/// Construct a block for widget using block properties.
-/// If focus is true the border color is applied, otherwise inactive_style
+/// If `focus` is `true`, [`Borders::style`] is applied as the Border style, if `false` `inactive_style` is applied, if `Some`.
 #[must_use]
 pub fn get_block(
     props: Borders,
@@ -78,6 +73,7 @@ pub fn get_block(
         .border_style(if focus {
             props.style()
         } else {
+            // TODO: remove the default "Reset"
             inactive_style.unwrap_or_else(|| Style::default().fg(Color::Reset).bg(Color::Reset))
         })
         .border_type(props.modifiers);
@@ -92,9 +88,8 @@ pub fn get_block(
     block
 }
 
-/// ### calc_utf8_cursor_position
+/// Calculate the actual amount of terminal space taken up, taking into account UTF things like multi-width, undrawn and combinatory characters.
 ///
-/// Calculate the UTF8 compliant position for the cursor given the characters preceeding the cursor position.
 /// Use this function to calculate cursor position whenever you want to handle UTF8 texts with cursors
 #[must_use]
 pub fn calc_utf8_cursor_position(chars: &[char]) -> u16 {
@@ -103,7 +98,7 @@ pub fn calc_utf8_cursor_position(chars: &[char]) -> u16 {
 
 /// Convert a `&Span` to a `Span` by using [`Cow::Borrowed`].
 ///
-/// Note that a normal `Span::clone` (and by extension `Cow::clone`) will preserve the `Cow` Variant.
+/// Note that a normal [`Span::clone`] (and by extension `Cow::clone`) will preserve the `Cow` Variant.
 pub fn borrow_clone_span<'a, 'b: 'a>(span: &'b Span<'a>) -> Span<'a> {
     Span {
         style: span.style,


### PR DESCRIPTION
# ISSUE _NUMBER_ - PULL_REQUEST_TITLE

~~Depends on #55~~

## Description

This PR fixes-up the documentation to not contain the extra headers, which were messing with the short-from descriptions.
re https://github.com/veeso/tui-realm/pull/160

Also add `modifiers` functions to components which did not have it previously.

## Type of change

Please select relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no new *C-bindings*
- [x] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit
